### PR TITLE
LLPP-0004: Add O(1) indexing capability using a hashmap

### DIFF
--- a/linked-list/DOCUMENTATION.md
+++ b/linked-list/DOCUMENTATION.md
@@ -50,6 +50,18 @@ Initializes an empty linked list with `head` set to `None`.
 
 #### Methods:
 
+##### `head()`
+Returns the head node of the list
+
+###### Examples:
+```python
+ll = LinkedList()
+ll.prepend(5)
+ll.prepend(10)
+print(ll.head().value)  # 5
+```
+---
+
 ##### `prepend(value)`
 Adds a new node to the front of the list.
 
@@ -109,7 +121,7 @@ b = Node(2, a)
 a.next = b  # cycle
 
 ll = LinkedList()
-ll.head = a
+ll._head = a # DO NOT DO THIS. Use public methods to affect the list instance
 ll.has_cycle()  # True
 ```
 ---

--- a/linked-list/DOCUMENTATION.md
+++ b/linked-list/DOCUMENTATION.md
@@ -1,7 +1,10 @@
 # 📘 Linked List Module Documentation
 
-This module implements a basic singly linked list using two core classes:
+A Python module implementing a custom singly linked list from scratch, with optional index map for O(1) lookups.
+Includes cycle detection, in-place reversal, and iteration support. Designed for learning, testing algorithms,
+and exploring hybrid data structures.
 
+Main Classes:
 - `Node`: Represents an element in the list
 - `LinkedList`: Provides operations for managing a sequence of nodes
 
@@ -48,7 +51,94 @@ print(n2 == n1) # False
 
 Initializes an empty linked list with `head` set to `None`.
 
-#### Methods:
+### Attributes:
+These attributes are internally managed and should not be manipulated externally.
+
+##### `self._head`
+The head node of the list. If the list is empty, self._head will be `None`.
+
+##### `self._index_map`
+The map of indexes paired with their corresponding nodes.
+
+##### `self._length`
+The amount of nodes in the list.
+
+### Dunder Methods:
+
+##### `__len__()`
+Returns the amount of nodes in the list.
+
+###### Examples:
+```python
+ll = LinkedList()
+ll.prepend(1)
+ll.prepend(2)
+
+len(ll)  # 2
+```
+---
+
+##### `__iter__()`
+Allows iteration over the linked list using a `for` loop.
+
+###### Raises:
+- `RuntimeError` if list contains a cycle
+
+###### Examples:
+```python
+ll = LinkedList()
+ll.prepend(1)
+ll.prepend(2)
+
+for value in ll:
+    print(value)
+# Output: 2, 1
+```
+---
+
+##### `__repr__()`
+Returns a string representation of the list, showing all node values.
+
+###### Examples:
+```python
+ll = LinkedList()
+ll.prepend(3)
+ll.prepend(2)
+ll.prepend(1)
+print(ll)  # LinkedList([1 -> 2 -> 3])
+
+ll.pop()
+ll.pop()
+ll.pop()
+print(ll) # Empty List
+```
+
+###### Cycle Safety:
+If a cycle is detected, prints up to the first repeated node and then:
+```python
+LinkedList([1 -> 2 -> 3 -> 1 ... (cycle detected)])
+```
+---
+
+###### `__getitem__(index)`
+Returns the value of the node at the given index.
+
+###### Examples:
+```python
+ll = LinkedList()
+ll.prepend(3)
+ll.prepend(2)
+ll.prepend(1)
+
+ll[0]  # 1
+ll[1]  # 2
+ll[2]  # 3
+```
+---
+
+### Public Methods:
+These are supported methods to manipulate, analyze, and examine the LinkedList instance. If only public methods are used
+to manipulate the LinkedList, the user can be assured that the list and its metadata will have reliable integrity.
 
 ##### `head()`
 Returns the head node of the list
@@ -78,7 +168,7 @@ print(ll)  # LinkedList([10 -> 5])
 ---
 
 ##### `classic_pop()`
-Removes and returns the value of the last node in the list with O(N) time complexity. Not recommended for use.
+Removes and returns the value of the tail node in the list with O(N) time complexity. This method is retained for instructional purposes only. Use `pop()` for production logic.
 
 ###### Returns:
 - `value` of the removed node
@@ -96,7 +186,7 @@ ll.classic_pop()  # None
 ---
 
 ##### `pop()`
-Removes and returns the value of the last node in the list with O(1) time complexity. Recommended method.
+Removes and returns the value of the tail node in the list with O(1) time complexity.
 
 ###### Returns:
 - `value` of the removed node
@@ -191,43 +281,81 @@ print(ll)  # LinkedList([1 -> 2 -> 3])
 ```
 ---
 
-##### `__iter__()`
-Allows iteration over the linked list using a `for` loop.
+##### `get_node(index)`
+Returns the node object at the given index.
+
+###### Arguments:
+- `index` (int): The position of the node.
+
+###### Returns:
+- The `Node` instance at the given index.
 
 ###### Raises:
-- `RuntimeError` if list contains a cycle
+- `IndexError` if the index is out of bounds.
+- `TypeError` if the index is not an integer.
 
 ###### Examples:
 ```python
 ll = LinkedList()
-ll.prepend(1)
-ll.prepend(2)
-
-for value in ll:
-    print(value)
-# Output: 2, 1
+ll.prepend(10)
+ll.prepend(20)
+node = ll.get_node(1)
+print(node.value)  # 10
 ```
 ---
 
-##### `__repr__()`
-Returns a string representation of the list, showing all node values.
+##### `rebuild_index_map()`
+Clears the current index map, and then traverses the list from head to tail, assigning a index to each node.
 
 ###### Examples:
 ```python
 ll = LinkedList()
-ll.prepend(3)
-ll.prepend(2)
-ll.prepend(1)
-print(ll)  # LinkedList([1 -> 2 -> 3])
+ll.prepend(10)
+ll.prepend(20)
+ll._index_map  # {0: Node(20), 1: Node(10)}
+ll.index_map = {}
 
-ll.pop()
-ll.pop()
-ll.pop()
-print(ll) # Empty List
+ll.rebuild_indes_map()
+ll._index_map  # {0: Node(20), 1: Node(10)}
 ```
+---
 
-###### Cycle Safety:
-If a cycle is detected, prints up to the first repeated node and then:
+##### `validate_index_map()`
+Validates the integrity of the index map by ensuring each indexed node in the map corresponds exactly to the node at that position in the linked list.
+
+###### Returns:
+- __Boolean__: `True` if index map is valid, `False` otherwise
+
+###### Examples:
 ```python
-LinkedList([1 -> 2 -> 3 -> 1 ... (cycle detected)])
+ll = LinkedList()
+ll.prepend(10)
+ll.prepend(20)
+ll._index_map  # {0: Node(20), 1: Node(10)}
+ll.validate_index_map()  # True
+
+ll.index_map = {}
+ll.validate_index_map()  # False
 ```
+---
+
+#### Private Methods:
+
+### 🔧 Internal Methods
+
+#### `_rebuild_index_map_partial(start_index, start_node)`
+Incrementally rebuilds the index map starting from `start_index` and `start_node`.
+
+Use only when it is known that preceding mappings are already correct. If in doubt, use `rebuild_index_map()`.
+
+#### `_add_node_to_index_map(index, node)`
+Adds an entry to the index map and updates mappings for all downstream nodes.
+
+#### `_remove_node_from_index_map(index)`
+Removes the specified index and rebuilds mappings for subsequent nodes if needed.
+
+#### `_increment_list_length()` / `_decrement_list_length()`
+Internal counters for maintaining list length.
+
+#### `_update_list_metadata_for_add_node()` / `_update_list_metadata_for_remove_node()`
+Helper methods that bundle together all index map and length updates for adding or removing nodes.

--- a/linked-list/DOCUMENTATION.md
+++ b/linked-list/DOCUMENTATION.md
@@ -77,8 +77,26 @@ print(ll)  # LinkedList([10 -> 5])
 ```
 ---
 
+##### `classic_pop()`
+Removes and returns the value of the last node in the list with O(N) time complexity. Not recommended for use.
+
+###### Returns:
+- `value` of the removed node
+- `None` if the list was empty
+
+###### Examples:
+```python
+ll = LinkedList()
+ll.prepend(1)
+ll.prepend(2)
+ll.classic_pop()  # 1
+ll.classic_pop()  # 2
+ll.classic_pop()  # None
+```
+---
+
 ##### `pop()`
-Removes and returns the value of the last node in the list.
+Removes and returns the value of the last node in the list with O(1) time complexity. Recommended method.
 
 ###### Returns:
 - `value` of the removed node
@@ -94,7 +112,6 @@ ll.pop()  # 2
 ll.pop()  # None
 ```
 ---
-
 ##### `is_empty()`
 Returns `True` if the list has no nodes, else `False`.
 

--- a/linked-list/README.md
+++ b/linked-list/README.md
@@ -34,7 +34,7 @@ print(ll.pop())  # 3
 
 ### Key Features
 - `prepend(value)` – Adds a node to the front of the list
-- `pop()` – Removes and returns the last node (O(1) with index map)
+- `pop()` – Removes and returns the tail node (O(1) with index map)
 - `has_cycle()` – Uses Floyd’s Tortoise-Hare algorithm to detect a cycle
 - `find_middle()` – Efficiently finds the middle node of the list
 - `reverse()` – Reverses the list in-place

--- a/linked-list/README.md
+++ b/linked-list/README.md
@@ -2,10 +2,10 @@
 
 ## Overview
 
-This module implements a singly linked list in Python from scratch, designed for educational use and algorithm practice. It includes two core classes:
+This module implements a custom singly linked list in Python with an optional index map for O(1) lookups—blending a simple data structure behavior with enhanced performance. It was built from scratch for educational purposes, hands-on algorithm practice, and clean code design.
 
-- `Node`: Represents a single element in the list, containing a value and a reference to the next node.
-- `LinkedList`: Provides a collection of nodes and various methods for working with them (e.g., prepend, pop, reverse, detect cycle, find middle).
+- `Node`: Represents a single element in the list, containing a value and a pointer to the next node.
+- `LinkedList`: Manages a collection of nodes and exposes methods for manipulating and analyzing.
 
 ---
 
@@ -34,17 +34,24 @@ print(ll.pop())  # 3
 
 ### Key Features
 - `prepend(value)` – Adds a node to the front of the list
-- `pop()` – Removes and returns the last node
+- `pop()` – Removes and returns the last node (O(1) with index map)
 - `has_cycle()` – Uses Floyd’s Tortoise-Hare algorithm to detect a cycle
 - `find_middle()` – Efficiently finds the middle node of the list
 - `reverse()` – Reverses the list in-place
-- `__iter__()` and `__repr__()` – Pythonic support for iteration and printing
+- `__getitem__(index)` - Access value at a given index using bracket notation.
+- `__iter__()`, `__repr__()`, `__len__()`– Pythonic iteration, printing, length
 
 ### Lessons Learned
 - `Cycle Detection`: Algorithms must guard against cycles to prevent infinite loops in iteration and string conversion.
 - `In-Place Reversal`: Managing pointer flipping can be complex; visualizing the node chain helps.
 - `Robustness`: Defensive programming practices (e.g., has_cycle checks) make this implementation resilient.
 - `Testing Philosophy`: Unit tests use the unittest module and follow the arrange-act-assert format for readability.
+- `Indexing`: Indexing transforms a linked list into a hybrid structure with powerful capabilities, but the index must be managed carefully internally to maximize performance.
+
+### Indexing Implementation
+This change made obvious the importance of public and internal methods. A corrupted index map is anti-useful, and exposing the management of the index to public use raises the risk of corrupting the index map.
+A series of internal methods were constructed to carefully manage the index map, without sacrificing performance for robustness. The methods are brittle, but fast.
+A safe method was made publicly available to completely rebuild the index map from scratch which ensures integrity.
 
 ### Testing
 This module is thoroughly tested using Python's unittest framework.
@@ -55,8 +62,6 @@ python -m unittest discover -s tests
 ```
 
 ### Where We Are Headed
- - Add documentation
- - Add O(1) lookups with indexes
  - Build new features enabled by indexed lookups
  - Transition to doubly linked list
  - Build new features enables by double link

--- a/linked-list/src/LinkedList.py
+++ b/linked-list/src/LinkedList.py
@@ -139,7 +139,7 @@ class LinkedList:
 
         self._update_list_metadata_for_add_node()
 
-    def pop(self):
+    def classic_pop(self):
         """
         Takes the node from the end of the list
 
@@ -163,6 +163,29 @@ class LinkedList:
         tail_node = current_node.next
         current_node.next = None
         self._update_list_metadata_for_remove_node(index_of_removed_node=index + 1)
+        return tail_node.value
+
+    def pop(self):
+        """
+        Takes the node from the end of the list
+
+        Return: the value of the removed node
+        """
+        if self.is_empty():
+            return None
+
+        if self._list_length == 1:
+            tail_node = self._head
+            self._head = None
+            self._update_list_metadata_for_remove_node(index_of_removed_node=0)
+            return tail_node.value
+
+        tail_index = self._list_length - 1
+        tail_node = self._index_map[tail_index]
+        penultimate_node = self._index_map[tail_index - 1]
+        penultimate_node.next = None  # cut the connection to the tail node
+
+        self._update_list_metadata_for_remove_node(index_of_removed_node=tail_index)
         return tail_node.value
 
     def has_cycle(self):

--- a/linked-list/src/LinkedList.py
+++ b/linked-list/src/LinkedList.py
@@ -367,3 +367,24 @@ class LinkedList:
             raise IndexError("Index out of bounds.")
 
         return self._index_map[index].value
+
+    def get_node(self, index: int):
+        """
+        Retrieves the node object at an index
+
+        Args:
+            index (int): The index of the node to retrieve.
+
+        Returns:
+            The node at the given index.
+
+        Raises:
+            IndexError: If the index is out of bounds.
+        """
+        if not isinstance(index, int):
+            raise TypeError("Index must be an integer.")
+
+        if index < 0 or index >= self._list_length:
+            raise IndexError("Index out of bounds.")
+
+        return self._index_map[index]

--- a/linked-list/src/LinkedList.py
+++ b/linked-list/src/LinkedList.py
@@ -8,6 +8,7 @@ class LinkedList:
         Sets the head to None
         """
         self._head = None
+        self._index_map = {}
 
     def head(self):
         """
@@ -21,9 +22,77 @@ class LinkedList:
         """
         return self._head is None
 
+    def rebuild_index_map(self, start_index: int = 0, start_node: Node = self._head):
+        """
+        Traverses the list and (re)assigns a sequential index to each node from the given starting point.
+
+        Args:
+            start_index (int): Index to begin mapping from. Defaults to 0.
+            start_node (Node): Node to begin mapping from. Defaults to the head of the list.
+
+        Notes:
+            If called with default arguments, this clears and fully rebuilds the index map.
+            If called with a custom start_index and start_node, it updates the map from that point forward.
+            In that case, earlier indices may remain stale, so ensure they were already accurate or explicitly updated.
+        """
+
+        # if rebuilding from scratch, clear self._index_map
+        if start_node == self._head or start_index == 0:
+            self._index_map = {}
+
+        current_node = start_node
+        index = start_index
+
+        # traverse the list and assign a sequential integer index to each node
+        while current_node:
+            self._index_map[index] = current_node
+            index += 1
+            current_node = current_node.next
+
+    def _remove_node_from_index_map(self, index):
+        """
+        Deletes the index, Node pair from self._index_map. Used when removing a node from the list
+        """
+
+        deleted_node = self._index_map.pop(index, None)
+
+        if deleted_node.next: # if there are subsequent nodes, an update must be done to the self._index_map
+            self.rebuild_index_map(index, deleted_node.next)
+
+    def _add_node_to_index_map(self, index, node):
+        """
+        Adds the index, Node pair to self._index_map. Used when adding a node to the list.
+        """
+        self._index_map[index] = node
+
+        if node.next: # if there are subsequent nodes, an update must be done to the self._index_map
+            self.rebuild_index_map(index + 1, node.next)
+
+    def validate_index_map(self):
+        """
+        Validates the integrity of the index map by ensuring each indexed node in the map corresponds exactly
+        to the node at that position in the linked list.
+
+        Returns:
+            bool: True if the index map is accurate and consistent with the current list structure;
+                  False if there are missing entries or incorrect mappings.
+
+        Use Cases:
+            - Debugging: Helps detect stale or corrupted index map entries.
+            - Testing: Can be used in unit tests to assert internal consistency after list operations.
+        """
+        current_node = self._head
+        index = 0
+
+        while current_node:
+            if index not in self._index_map or self._index_map[index] != current_node:
+                return False
+            index += 1
+            current_node = current_node.next
+
     def prepend(self, value):
         """
-        Adds a node to the fron or the head of the linked list
+        Adds a node to the front or the head of the linked list
 
         Args:
             value: The value to store in the node that will be prepended
@@ -48,6 +117,7 @@ class LinkedList:
         if not self._head.next:
             tail_value = self._head.value
             self._head = None
+
             return tail_value
 
         current_node = self._head

--- a/linked-list/src/LinkedList.py
+++ b/linked-list/src/LinkedList.py
@@ -9,6 +9,7 @@ class LinkedList:
         """
         self._head = None
         self._index_map = {}
+        self._list_length = 0
 
     def head(self):
         """
@@ -22,28 +23,34 @@ class LinkedList:
         """
         return self._head is None
 
-    def rebuild_index_map(self, start_index: int = 0, start_node: Node = self._head):
+    def rebuild_index_map(self):
         """
-        Traverses the list and (re)assigns a sequential index to each node from the given starting point.
+        Rebuilds index map from scratch.
+        """
+        self._index_map = {}
+        self._rebuild_index_map_partial(start_index=0, start_node=self._head)
+
+    def _rebuild_index_map_partial(self, start_index: int, start_node: Node):
+        """
+        Rebuilds a portion of the index map starting from the given index and node.
+
+        This internal method assumes that the provided start_index and start_node
+        accurately reflect the correct position of the node within the list. It updates
+        self._index_map in place by traversing from start_node and assigning sequential
+        indices starting from start_index.
 
         Args:
-            start_index (int): Index to begin mapping from. Defaults to 0.
-            start_node (Node): Node to begin mapping from. Defaults to the head of the list.
+            start_index (int): The index to begin assigning to start_node.
+            start_node (Node): The node at which to begin rebuilding the index map.
 
-        Notes:
-            If called with default arguments, this clears and fully rebuilds the index map.
-            If called with a custom start_index and start_node, it updates the map from that point forward.
-            In that case, earlier indices may remain stale, so ensure they were already accurate or explicitly updated.
+        NOTE:
+            This method performs no validation of inputs. It is intended for internal use
+            only, where the correctness of inputs can be guaranteed by the calling method.
+            If index map must be fully rebuilt, use the public `rebuild_index_map()` method instead.
         """
-
-        # if rebuilding from scratch, clear self._index_map
-        if start_node == self._head or start_index == 0:
-            self._index_map = {}
-
         current_node = start_node
         index = start_index
 
-        # traverse the list and assign a sequential integer index to each node
         while current_node:
             self._index_map[index] = current_node
             index += 1
@@ -53,11 +60,10 @@ class LinkedList:
         """
         Deletes the index, Node pair from self._index_map. Used when removing a node from the list
         """
-
         deleted_node = self._index_map.pop(index, None)
 
-        if deleted_node.next: # if there are subsequent nodes, an update must be done to the self._index_map
-            self.rebuild_index_map(index, deleted_node.next)
+        if deleted_node.next:  # if there are subsequent nodes, an update must be done to the self._index_map
+            self._rebuild_index_map_partial(index, deleted_node.next)
 
     def _add_node_to_index_map(self, index, node):
         """
@@ -65,8 +71,8 @@ class LinkedList:
         """
         self._index_map[index] = node
 
-        if node.next: # if there are subsequent nodes, an update must be done to the self._index_map
-            self.rebuild_index_map(index + 1, node.next)
+        if node.next:  # if there are subsequent nodes, an update must be done to the self._index_map
+            self._rebuild_index_map_partial(index + 1, node.next)
 
     def validate_index_map(self):
         """
@@ -75,7 +81,7 @@ class LinkedList:
 
         Returns:
             bool: True if the index map is accurate and consistent with the current list structure;
-                  False if there are missing entries or incorrect mappings.
+                  False if there are stale entries, missing entries, or incorrect mappings.
 
         Use Cases:
             - Debugging: Helps detect stale or corrupted index map entries.
@@ -84,11 +90,16 @@ class LinkedList:
         current_node = self._head
         index = 0
 
+        if len(self._index_map) != self._list_length: # if there are a different number of nodes than index mappings
+            return False
+
         while current_node:
             if index not in self._index_map or self._index_map[index] != current_node:
                 return False
             index += 1
             current_node = current_node.next
+
+        return True
 
     def prepend(self, value):
         """
@@ -105,6 +116,8 @@ class LinkedList:
             new_node.next = self._head
             self._head = new_node
 
+        self._list_length += 1
+
     def pop(self):
         """
         Takes the node from the end of the list
@@ -117,7 +130,7 @@ class LinkedList:
         if not self._head.next:
             tail_value = self._head.value
             self._head = None
-
+            self._list_length -= 1
             return tail_value
 
         current_node = self._head
@@ -126,6 +139,7 @@ class LinkedList:
 
         tail_value = current_node.next.value
         current_node.next = None
+        self._list_length -= 1
         return tail_value
 
     def has_cycle(self):

--- a/linked-list/src/LinkedList.py
+++ b/linked-list/src/LinkedList.py
@@ -277,3 +277,35 @@ class LinkedList:
             current_node = current_node.next
 
         return "LinkedList([" + " -> ".join(node_values) + "])"
+
+    def __len__(self):
+        """
+        The number of nodes in the linked list.
+
+        Returns:
+            int: The length of the list.
+        """
+        return self._list_length
+
+    def __getitem__(self, index: int):
+        """
+        Allows bracket-style indexing into the linked list.
+        Example: my_list[2]
+
+        Args:
+            index (int): The index of the node to retrieve.
+
+        Returns:
+            The value of the node at the given index.
+
+        Raises:
+            IndexError: If the index is out of bounds.
+        """
+        if not isinstance(index, int):
+            raise TypeError("Index must be an integer.")
+
+        if index < 0 or index >= self._list_length:
+            raise IndexError("Index out of bounds.")
+
+        return self._index_map[index].value
+

--- a/linked-list/src/LinkedList.py
+++ b/linked-list/src/LinkedList.py
@@ -7,13 +7,19 @@ class LinkedList:
         Initializes an empty singly linked list
         Sets the head to None
         """
-        self.head = None
+        self._head = None
+
+    def head(self):
+        """
+        Return the head of the list
+        """
+        return self._head
 
     def is_empty(self) -> bool:
         """
         Returns True if the list is empty, False otherwise.
         """
-        return self.head is None
+        return self._head is None
 
     def prepend(self, value):
         """
@@ -25,10 +31,10 @@ class LinkedList:
         new_node = Node(value)
 
         if self.is_empty():
-            self.head = new_node
+            self._head = new_node
         else:
-            new_node.next = self.head
-            self.head = new_node
+            new_node.next = self._head
+            self._head = new_node
 
     def pop(self):
         """
@@ -39,12 +45,12 @@ class LinkedList:
         if self.is_empty():
             return None
 
-        if not self.head.next:
-            tail_value = self.head.value
-            self.head = None
+        if not self._head.next:
+            tail_value = self._head.value
+            self._head = None
             return tail_value
 
-        current_node = self.head
+        current_node = self._head
         while current_node.next.next:  # stop at the penultimate node
             current_node = current_node.next
 
@@ -72,8 +78,8 @@ class LinkedList:
         #     return False
 
         # set both pointers equal to head to get both racers to the starting line
-        hare_pointer = self.head
-        tortoise_pointer = self.head
+        hare_pointer = self._head
+        tortoise_pointer = self._head
 
         while hare_pointer and hare_pointer.next:
             # if the hare pointer or next node is None then you have reached the end of the list and there's no cycle
@@ -105,8 +111,8 @@ class LinkedList:
         if self.has_cycle():
             raise RuntimeError("Cannot find the middle of a cyclical linked list")
 
-        hare_pointer = self.head
-        tortoise_pointer = self.head
+        hare_pointer = self._head
+        tortoise_pointer = self._head
 
         while hare_pointer and hare_pointer.next:
             # if the hare pointer or next node is None then you have reached the end of the list
@@ -122,8 +128,8 @@ class LinkedList:
         Reverses the order of the nodes in place using 3 pointers
 
         Explanation:
-            The first pointer is called next_node and points to self.head. The next pointer points to self.head.next
-            and calls it current_node. The final pointer points to self.head.next.next and calls it previous. Now
+            The first pointer is called next_node and points to self._head. The next pointer points to self._head.next
+            and calls it current_node. The final pointer points to self._head.next.next and calls it previous. Now
             picture that you are physically traversing this list. You stand at head, and turn backwards. Head's pointer
             now points backwards between your legs to self.next. You flip that pointer around to point at nothing and
             then you hop back to the next node. You flip that nodes pointer around to point at head. You hop backwards
@@ -132,13 +138,13 @@ class LinkedList:
             pointer of the node we are standing on. The first time I encountered this strategy, I was super confused.
             I wonder if this made it more or less complicated :)
         """
-        if self.is_empty() or self.head.next is None:
+        if self.is_empty() or self._head.next is None:
             return  # Nothing to reverse
         if self.has_cycle():
             raise RuntimeError("Cannot reverse a cyclical linked list")
 
         previous_node = None
-        current_node = self.head
+        current_node = self._head
 
         while current_node:
             next_node = current_node.next  # store the next node
@@ -146,7 +152,7 @@ class LinkedList:
             previous_node = current_node  # move previous forward
             current_node = next_node  # move current forward
 
-        self.head = previous_node
+        self._head = previous_node
 
     def __iter__(self):
         """
@@ -157,7 +163,7 @@ class LinkedList:
         """
         if self.has_cycle():
             raise RuntimeError("Cannot iterate over a cyclic linked list")
-        current_node = self.head
+        current_node = self._head
         while current_node:
             yield current_node.value
             current_node = current_node.next
@@ -173,7 +179,7 @@ class LinkedList:
             return "Empty List"
 
         node_values = []
-        current_node = self.head
+        current_node = self._head
         visited_nodes = set()
 
         while current_node:

--- a/linked-list/src/LinkedList.py
+++ b/linked-list/src/LinkedList.py
@@ -169,7 +169,7 @@ class LinkedList:
 
     def pop(self):
         """
-        Takes the node from the end of the list
+        Removes the tail node from the list
 
         Return: the value of the removed node
         """
@@ -184,7 +184,7 @@ class LinkedList:
             self._update_list_metadata_for_remove_node(index_of_removed_node=0)
             return tail_node.value
 
-        # Get the index of the last node
+        # Get the index of the tail node
         tail_index = self._list_length - 1
 
         # Use the index map to retrieve the tail and the node just before it

--- a/linked-list/src/LinkedList.py
+++ b/linked-list/src/LinkedList.py
@@ -56,24 +56,6 @@ class LinkedList:
             index += 1
             current_node = current_node.next
 
-    def _remove_node_from_index_map(self, index):
-        """
-        Deletes the index, Node pair from self._index_map. Used when removing a node from the list
-        """
-        deleted_node = self._index_map.pop(index, None)
-
-        if deleted_node.next:  # if there are subsequent nodes, an update must be done to the self._index_map
-            self._rebuild_index_map_partial(index, deleted_node.next)
-
-    def _add_node_to_index_map(self, index, node):
-        """
-        Adds the index, Node pair to self._index_map. Used when adding a node to the list.
-        """
-        self._index_map[index] = node
-
-        if node.next:  # if there are subsequent nodes, an update must be done to the self._index_map
-            self._rebuild_index_map_partial(index + 1, node.next)
-
     def validate_index_map(self):
         """
         Validates the integrity of the index map by ensuring each indexed node in the map corresponds exactly
@@ -90,7 +72,7 @@ class LinkedList:
         current_node = self._head
         index = 0
 
-        if len(self._index_map) != self._list_length: # if there are a different number of nodes than index mappings
+        if len(self._index_map) != self._list_length:  # if there are a different number of nodes than index mappings
             return False
 
         while current_node:
@@ -100,6 +82,45 @@ class LinkedList:
             current_node = current_node.next
 
         return True
+
+    def _remove_node_from_index_map(self, index):
+        """
+        Deletes the index, Node pair from self._index_map. Used when removing a node from the list
+        """
+        deleted_node = self._index_map.pop(index, None)
+
+        last_index = self._list_length - 1
+        if index != last_index:  # if the index of the deleted node was not the last index
+            del self._index_map[last_index]  # delete tail node from index_map as it would be stale after rebuild
+
+        if deleted_node.next:  # if there are subsequent nodes, an update must be done to the self._index_map
+            self._rebuild_index_map_partial(index, deleted_node.next)
+
+    def _add_node_to_index_map(self, index, node):
+        """
+        Adds the index, Node pair to self._index_map. Used when adding a node to the list.
+        """
+        if not node:
+            node = self._head
+
+        self._index_map[index] = node
+
+        if node.next:  # if there are subsequent nodes, an update must be done to the self._index_map
+            self._rebuild_index_map_partial(index + 1, node.next)
+
+    def _increment_list_length(self):
+        self._list_length += 1
+
+    def _decrement_list_length(self):
+        self._list_length -= 1
+
+    def _update_list_metadata_for_add_node(self, index_to_add_node: int = 0, added_node: Node = None):
+        self._add_node_to_index_map(index_to_add_node, added_node)
+        self._increment_list_length()
+
+    def _update_list_metadata_for_remove_node(self, index_of_removed_node: int = 0):
+        self._remove_node_from_index_map(index_of_removed_node)
+        self._decrement_list_length()
 
     def prepend(self, value):
         """
@@ -116,7 +137,7 @@ class LinkedList:
             new_node.next = self._head
             self._head = new_node
 
-        self._list_length += 1
+        self._update_list_metadata_for_add_node()
 
     def pop(self):
         """
@@ -128,19 +149,21 @@ class LinkedList:
             return None
 
         if not self._head.next:
-            tail_value = self._head.value
+            tail_node = self._head
             self._head = None
-            self._list_length -= 1
-            return tail_value
+            self._update_list_metadata_for_remove_node(index_of_removed_node=0)
+            return tail_node.value
 
+        index = 0
         current_node = self._head
         while current_node.next.next:  # stop at the penultimate node
             current_node = current_node.next
+            index += 1
 
-        tail_value = current_node.next.value
+        tail_node = current_node.next
         current_node.next = None
-        self._list_length -= 1
-        return tail_value
+        self._update_list_metadata_for_remove_node(index_of_removed_node=index + 1)
+        return tail_node.value
 
     def has_cycle(self):
         """
@@ -230,11 +253,14 @@ class LinkedList:
         previous_node = None
         current_node = self._head
 
+        index = self._list_length - 1
         while current_node:
             next_node = current_node.next  # store the next node
             current_node.next = previous_node  # reverse the pointer
             previous_node = current_node  # move previous forward
+            self._index_map[index] = current_node  # update the index map
             current_node = next_node  # move current forward
+            index -= 1
 
         self._head = previous_node
 
@@ -309,3 +335,10 @@ class LinkedList:
 
         return self._index_map[index].value
 
+
+"""
+okay so i am thinking we bundle adding and removing nodes from the list into different wrappers
+i probably need to refine that name because the wrapper will not be the one removing the node or adding it,
+the function that calls the wrapper will do that.
+the wrapper will be updating the index map and the list length attribute. 
+"""

--- a/linked-list/src/LinkedList.py
+++ b/linked-list/src/LinkedList.py
@@ -6,6 +6,8 @@ class LinkedList:
         """
         Initializes an empty singly linked list
         Sets the head to None
+        Initializes empty index map
+        Sets list length to 0
         """
         self._head = None
         self._index_map = {}
@@ -45,7 +47,7 @@ class LinkedList:
 
         NOTE:
             This method performs no validation of inputs. It is intended for internal use
-            only, where the correctness of inputs can be guaranteed by the calling method.
+            only, where the correctness of inputs is assumed.
             If index map must be fully rebuilt, use the public `rebuild_index_map()` method instead.
         """
         current_node = start_node
@@ -89,9 +91,9 @@ class LinkedList:
         """
         deleted_node = self._index_map.pop(index, None)
 
-        last_index = self._list_length - 1
-        if index != last_index:  # if the index of the deleted node was not the last index
-            del self._index_map[last_index]  # delete tail node from index_map as it would be stale after rebuild
+        tail_index = self._list_length - 1
+        if index != tail_index:  # if the index of the deleted node was not the tail index
+            del self._index_map[tail_index]  # delete tail node from index_map as it would be stale after rebuild
 
         if deleted_node.next:  # if there are subsequent nodes, an update must be done to the self._index_map
             self._rebuild_index_map_partial(index, deleted_node.next)
@@ -171,21 +173,29 @@ class LinkedList:
 
         Return: the value of the removed node
         """
+        # If the list is empty, there's nothing to remove
         if self.is_empty():
             return None
 
+        # Handle the case where there's only one node in the list
         if self._list_length == 1:
             tail_node = self._head
             self._head = None
             self._update_list_metadata_for_remove_node(index_of_removed_node=0)
             return tail_node.value
 
+        # Get the index of the last node
         tail_index = self._list_length - 1
+
+        # Use the index map to retrieve the tail and the node just before it
         tail_node = self._index_map[tail_index]
         penultimate_node = self._index_map[tail_index - 1]
+
+        # Remove the tail by setting the penultimate node's next to None
         penultimate_node.next = None  # cut the connection to the tail node
 
         self._update_list_metadata_for_remove_node(index_of_removed_node=tail_index)
+
         return tail_node.value
 
     def has_cycle(self):
@@ -204,9 +214,6 @@ class LinkedList:
 
         Return: a boolean indicating whether a cycle exists in the list
         """
-        # if self.is_empty():  # if there are no nodes
-        #     return False
-
         # set both pointers equal to head to get both racers to the starting line
         hare_pointer = self._head
         tortoise_pointer = self._head
@@ -257,16 +264,17 @@ class LinkedList:
         """
         Reverses the order of the nodes in place using 3 pointers
 
-        Explanation:
-            The first pointer is called next_node and points to self._head. The next pointer points to self._head.next
-            and calls it current_node. The final pointer points to self._head.next.next and calls it previous. Now
-            picture that you are physically traversing this list. You stand at head, and turn backwards. Head's pointer
-            now points backwards between your legs to self.next. You flip that pointer around to point at nothing and
-            then you hop back to the next node. You flip that nodes pointer around to point at head. You hop backwards
-            again, and flip that nodes pointer to the one you were just at. So on and so on. This is essentially what is
-            happening, and that is why we need the "next" point: to know where to jump after we have flipped the
-            pointer of the node we are standing on. The first time I encountered this strategy, I was super confused.
-            I wonder if this made it more or less complicated :)
+        Explanation: The first pointer is called current_node and points to self._head. The next pointer points to
+        current_node.next and calls it next_node. The final pointer points to self._head after the pointer has been
+        reversed and calls it previous.
+
+        Now picture that you are physically traversing this list. You stand at head, and turn backwards. Head's
+        pointer now points backwards between your legs to self.next. You flip that pointer around to point at nothing
+        and then you hop back to the next node. You flip that nodes pointer around to point at head. You hop
+        backwards again, and flip that nodes pointer to the one you were just at. So on and so on. This is
+        essentially what is happening, and that is why we need the "next" point: to know where to jump after we have
+        flipped the pointer of the node we are standing on. The first time I encountered this strategy, I was super
+        confused. I wonder if this made it more or less complicated :)
         """
         if self.is_empty() or self._head.next is None:
             return  # Nothing to reverse
@@ -294,6 +302,7 @@ class LinkedList:
         Raises:
             Runtime Error when list has a cycle to prevent endless recursion upon iterating
         """
+        # TODO: optimize this. we cannot be checking in a performance critical method whether or not the list has a cycle. Let a recursion error generate if the user decided to create a cycle in their list
         if self.has_cycle():
             raise RuntimeError("Cannot iterate over a cyclic linked list")
         current_node = self._head
@@ -308,6 +317,7 @@ class LinkedList:
         NOTE:
             If the list has a cycle, the representation only shows up to the first repeat
         """
+        # TODO: should we limit how many nodes will be printed?
         if self.is_empty():
             return "Empty List"
 
@@ -320,7 +330,7 @@ class LinkedList:
                 node_values.append(f"{str(current_node.value)} ... (cycle detected)")
                 break
 
-            # add to node_values list and visted_nodes set and advance to the next node
+            # add to node_values list and visited_nodes set and advance to the next node
             node_values.append(str(current_node.value))
             visited_nodes.add(id(current_node))
             current_node = current_node.next
@@ -357,11 +367,3 @@ class LinkedList:
             raise IndexError("Index out of bounds.")
 
         return self._index_map[index].value
-
-
-"""
-okay so i am thinking we bundle adding and removing nodes from the list into different wrappers
-i probably need to refine that name because the wrapper will not be the one removing the node or adding it,
-the function that calls the wrapper will do that.
-the wrapper will be updating the index map and the list length attribute. 
-"""

--- a/linked-list/tests/test_LinkedList.py
+++ b/linked-list/tests/test_LinkedList.py
@@ -416,6 +416,37 @@ class TestLinkedList(unittest.TestCase):
 
         self.assertEqual(str(context.exception), "Cannot reverse a cyclical linked list")
 
+    def test_getitem_non_int_index(self):
+        # Arrange
+        test_list = create_list_from_values(["D", "C", "B", "A"])
+        test_list.rebuild_index_map()
+
+        # Act & Assert
+        with self.assertRaises(TypeError) as context:
+            test_list["1"]
+
+        self.assertEqual(str(context.exception), "Index must be an integer.")
+    def test_getitem_out_of_bounds_index(self):
+        # Arrange
+        test_list = create_list_from_values(["D", "C", "B", "A"])
+        test_list.rebuild_index_map()
+
+        # Act & Assert
+        with self.assertRaises(IndexError) as context:
+            test_list[4]
+
+        self.assertEqual(str(context.exception), "Index out of bounds.")
+
+    def test_getitem_valid_index(self):
+        # Arrange
+        test_list = create_list_from_values(["D", "C", "B", "A"])
+        test_list.rebuild_index_map()
+
+        # Act
+        result = test_list[0]
+
+        # Assert
+        self.assertEqual(result, "A")
 
 ###### HELPER FUNCTIONS ######
 def create_list_from_values(values):

--- a/linked-list/tests/test_LinkedList.py
+++ b/linked-list/tests/test_LinkedList.py
@@ -18,6 +18,8 @@ class TestLinkedList(unittest.TestCase):
 
         # Assert
         self.assertEqual(repr(test_list), "Empty List")
+        self.assertEqual(len(test_list), 0)
+        self.assertEqual(test_list._index_map, {})
 
     def test_head(self):
         # Arrange
@@ -90,7 +92,6 @@ class TestLinkedList(unittest.TestCase):
     def test_validate_index_map_valid_map(self):
         # Arrange
         test_list = create_list_from_values(["C", "B", "A"])
-        test_list.rebuild_index_map()
 
         # Act & Assert
         self.assertTrue(test_list.validate_index_map())
@@ -98,7 +99,6 @@ class TestLinkedList(unittest.TestCase):
     def test_validate_index_map_stale_index(self):
         # Arrange
         test_list = create_list_from_values(["C", "B", "A"])
-        test_list.rebuild_index_map()
         # pop node_c, but restore it to the index map
         node_c_value = test_list.pop()
         test_list._index_map[2] = Node(node_c_value)
@@ -109,7 +109,6 @@ class TestLinkedList(unittest.TestCase):
     def test_validate_index_map_incorrect_mapping(self):
         # Arrange
         test_list = create_list_from_values(["C", "B", "A"])
-        test_list.rebuild_index_map()
         node_a = test_list.head()
         node_b = node_a.next
         # switch indexes of node_a and node_b
@@ -122,7 +121,6 @@ class TestLinkedList(unittest.TestCase):
     def test_validate_index_map_missing_mapping(self):
         # Arrange
         test_list = create_list_from_values(["C", "B", "A"])
-        test_list.rebuild_index_map()
         test_list._index_map.pop(2)  # get rid of index 2 in the index map
 
         # Act & Assert
@@ -311,18 +309,9 @@ class TestLinkedList(unittest.TestCase):
     def test_repr_list_with_cycle(self):
         # Arrange
         test_list = create_list_from_values(["G", "F", "E", "D", "C", "B", "A"])
-        # traverse list and to get node "B" and node "G"
-        current_node = test_list._head
-        while current_node:
-            if current_node.value == "B":
-                node_B = current_node
-
-            if current_node.value == "G":
-                node_G = current_node
-
-            current_node = current_node.next
-
-        node_G.next = node_B  # set node "G" next to node "B"
+        node_b = test_list.get_node(1)
+        node_g = test_list.get_node(6)
+        node_g.next = node_b  # set node "G" next to node "B"
 
         # Assert
         self.assertEqual(repr(test_list), "LinkedList([A -> B -> C -> D -> E -> F -> G -> B ... (cycle detected)])")
@@ -346,7 +335,7 @@ class TestLinkedList(unittest.TestCase):
         # Arrange
         test_list = LinkedList()
         test_list.prepend("A")
-        test_list._head.next = test_list._head  # set head equal to itself. single node loop
+        test_list._head.next = test_list._head  # set head.next equal to itself. single node loop
 
         # Act & Assert
         self.assertTrue(test_list.has_cycle())
@@ -376,17 +365,8 @@ class TestLinkedList(unittest.TestCase):
     def test_has_cycle_multi_node_list_with_cycle(self):
         # Arrange
         test_list = create_list_from_values(["G", "F", "E", "D", "C", "B", "A"])
-        # traverse list and to get node "B" and node "G"
-        current_node = test_list._head
-        while current_node:
-            if current_node.value == "B":
-                node_b = current_node
-
-            if current_node.value == "G":
-                node_g = current_node
-
-            current_node = current_node.next
-
+        node_b = test_list.get_node(1)
+        node_g = test_list.get_node(6)
         node_g.next = node_b  # set node "G" next to node "B"
 
         # Act & Assert
@@ -480,7 +460,6 @@ class TestLinkedList(unittest.TestCase):
     def test_getitem_non_int_index(self):
         # Arrange
         test_list = create_list_from_values(["D", "C", "B", "A"])
-        test_list.rebuild_index_map()
 
         # Act & Assert
         with self.assertRaises(TypeError) as context:
@@ -491,7 +470,6 @@ class TestLinkedList(unittest.TestCase):
     def test_getitem_out_of_bounds_index(self):
         # Arrange
         test_list = create_list_from_values(["D", "C", "B", "A"])
-        test_list.rebuild_index_map()
 
         # Act & Assert
         with self.assertRaises(IndexError) as context:
@@ -502,7 +480,6 @@ class TestLinkedList(unittest.TestCase):
     def test_getitem_valid_index(self):
         # Arrange
         test_list = create_list_from_values(["D", "C", "B", "A"])
-        test_list.rebuild_index_map()
 
         # Act
         result = test_list[0]
@@ -510,6 +487,36 @@ class TestLinkedList(unittest.TestCase):
         # Assert
         self.assertEqual(result, "A")
 
+    def test_get_node_non_int_index(self):
+        # Arrange
+        test_list = create_list_from_values(["D", "C", "B", "A"])
+
+        # Act & Assert
+        with self.assertRaises(TypeError) as context:
+            test_list.get_node("1")
+
+        self.assertEqual(str(context.exception), "Index must be an integer.")
+
+    def test_get_node_out_of_bounds_index(self):
+        # Arrange
+        test_list = create_list_from_values(["D", "C", "B", "A"])
+
+        # Act & Assert
+        with self.assertRaises(IndexError) as context:
+            test_list.get_node(4)
+
+        self.assertEqual(str(context.exception), "Index out of bounds.")
+
+    def test_get_node_valid_index(self):
+        # Arrange
+        test_list = create_list_from_values(["D", "C", "B", "A"])
+        node_a = test_list._head
+
+        # Act
+        result = test_list.get_node(0)
+
+        # Assert
+        self.assertEqual(result, node_a)
 
 ###### HELPER FUNCTIONS ######
 def create_list_from_values(values):

--- a/linked-list/tests/test_LinkedList.py
+++ b/linked-list/tests/test_LinkedList.py
@@ -153,6 +153,58 @@ class TestLinkedList(unittest.TestCase):
         self.assertTrue(test_list.validate_index_map())
         self.assertEqual(len(test_list), 2)
 
+    def test_classic_pop_node_from_empty_list(self):
+        # Arrange
+        test_list = create_list_from_values([])
+
+        # Act
+        pop_value = test_list.classic_pop()
+
+        # Assert
+        self.assertIsNone(pop_value)
+        self.assertEqual(repr(test_list), "Empty List")
+        self.assertTrue(test_list.validate_index_map())
+        self.assertEqual(len(test_list), 0)
+
+    def test_classic_pop_node_from_single_node_list(self):
+        # Arrange
+        test_list = create_list_from_values([1])
+
+        # Act
+        pop_value = test_list.classic_pop()
+
+        # Assert
+        self.assertEqual(pop_value, 1)
+        self.assertEqual(repr(test_list), "Empty List")
+        self.assertTrue(test_list.validate_index_map())
+        self.assertEqual(len(test_list), 0)
+
+    def test_classic_pop_node_from_two_node_list(self):
+        # Arrange
+        test_list = create_list_from_values([1, 2])
+
+        # Act
+        pop_value = test_list.classic_pop()
+
+        # Assert
+        self.assertEqual(pop_value, 1)
+        self.assertEqual(repr(test_list), "LinkedList([2])")
+        self.assertTrue(test_list.validate_index_map())
+        self.assertEqual(len(test_list), 1)
+
+    def test_classic_pop_node_from_multiple_node_list(self):
+        # Arrange
+        test_list = create_list_from_values([1, 2, 3, 4])
+
+        # Act
+        pop_value = test_list.classic_pop()
+
+        # Assert
+        self.assertEqual(pop_value, 1)
+        self.assertEqual(repr(test_list), "LinkedList([4 -> 3 -> 2])")
+        self.assertTrue(test_list.validate_index_map())
+        self.assertEqual(len(test_list), 3)
+
     def test_pop_node_from_empty_list(self):
         # Arrange
         test_list = create_list_from_values([])

--- a/linked-list/tests/test_LinkedList.py
+++ b/linked-list/tests/test_LinkedList.py
@@ -64,10 +64,7 @@ class TestLinkedList(unittest.TestCase):
         test_list.rebuild_index_map()
 
         # Assert
-        self.assertEqual(test_list._index_map[0].value, "A")
-        self.assertEqual(test_list._index_map[1].value, "B")
-        self.assertEqual(test_list._index_map[2].value, "C")
-        self.assertEqual(test_list._index_map[3].value, "D")
+        self.assertTrue(test_list.validate_index_map())
 
     def test_rebuild_index_map_empty_list(self):
         # Arrange
@@ -77,21 +74,18 @@ class TestLinkedList(unittest.TestCase):
         test_list.rebuild_index_map()
 
         # Assert
-        with self.assertRaises(KeyError) as context:
-            test_list._index_map[0]
+        self.assertTrue(test_list.validate_index_map())
 
     def test__rebuild_index_map_partial(self):
         # Arrange
         test_list = create_list_from_values(["C", "B", "A"])
         node_b = test_list.head().next
-        node_c = node_b.next
 
         # Act
         test_list._rebuild_index_map_partial(start_index=1, start_node=node_b)
 
         # Assert
-        self.assertEqual(test_list._index_map[1], node_b)
-        self.assertEqual(test_list._index_map[2], node_c)
+        self.assertTrue(test_list.validate_index_map())
 
     def test_validate_index_map_valid_map(self):
         # Arrange
@@ -143,6 +137,8 @@ class TestLinkedList(unittest.TestCase):
 
         # Assert
         self.assertEqual(repr(test_list), "LinkedList([5])")
+        self.assertTrue(test_list.validate_index_map())
+        self.assertEqual(len(test_list), 1)
 
     def test_prepend_to_list(self):
         # Arrange
@@ -154,6 +150,8 @@ class TestLinkedList(unittest.TestCase):
 
         # Assert
         self.assertEqual(repr(test_list), "LinkedList([6 -> 5])")
+        self.assertTrue(test_list.validate_index_map())
+        self.assertEqual(len(test_list), 2)
 
     def test_pop_node_from_empty_list(self):
         # Arrange
@@ -165,6 +163,8 @@ class TestLinkedList(unittest.TestCase):
         # Assert
         self.assertIsNone(pop_value)
         self.assertEqual(repr(test_list), "Empty List")
+        self.assertTrue(test_list.validate_index_map())
+        self.assertEqual(len(test_list), 0)
 
     def test_pop_node_from_single_node_list(self):
         # Arrange
@@ -176,6 +176,8 @@ class TestLinkedList(unittest.TestCase):
         # Assert
         self.assertEqual(pop_value, 1)
         self.assertEqual(repr(test_list), "Empty List")
+        self.assertTrue(test_list.validate_index_map())
+        self.assertEqual(len(test_list), 0)
 
     def test_pop_node_from_two_node_list(self):
         # Arrange
@@ -187,6 +189,8 @@ class TestLinkedList(unittest.TestCase):
         # Assert
         self.assertEqual(pop_value, 1)
         self.assertEqual(repr(test_list), "LinkedList([2])")
+        self.assertTrue(test_list.validate_index_map())
+        self.assertEqual(len(test_list), 1)
 
     def test_pop_node_from_multiple_node_list(self):
         # Arrange
@@ -198,6 +202,8 @@ class TestLinkedList(unittest.TestCase):
         # Assert
         self.assertEqual(pop_value, 1)
         self.assertEqual(repr(test_list), "LinkedList([4 -> 3 -> 2])")
+        self.assertTrue(test_list.validate_index_map())
+        self.assertEqual(len(test_list), 3)
 
     def test_iterating_over_list(self):
         # Arrange
@@ -384,6 +390,7 @@ class TestLinkedList(unittest.TestCase):
 
         # Assert
         self.assertEqual(repr(test_list), "LinkedList([I -> H -> G -> F -> E -> D -> C -> B -> A])")
+        self.assertTrue(test_list.validate_index_map())
 
     def test_reverse_single_node_list(self):
         # Arrange
@@ -394,6 +401,7 @@ class TestLinkedList(unittest.TestCase):
 
         # Assert
         self.assertEqual(repr(test_list), "LinkedList([A])")
+        self.assertTrue(test_list.validate_index_map())
 
     def test_reverse_empty_list(self):
         # Arrange
@@ -404,6 +412,7 @@ class TestLinkedList(unittest.TestCase):
 
         # Assert
         self.assertEqual(repr(test_list), "Empty List")
+        self.assertTrue(test_list.validate_index_map())
 
     def test_reverse_cyclical_list(self):
         # Arrange
@@ -426,6 +435,7 @@ class TestLinkedList(unittest.TestCase):
             test_list["1"]
 
         self.assertEqual(str(context.exception), "Index must be an integer.")
+
     def test_getitem_out_of_bounds_index(self):
         # Arrange
         test_list = create_list_from_values(["D", "C", "B", "A"])
@@ -447,6 +457,7 @@ class TestLinkedList(unittest.TestCase):
 
         # Assert
         self.assertEqual(result, "A")
+
 
 ###### HELPER FUNCTIONS ######
 def create_list_from_values(values):

--- a/linked-list/tests/test_LinkedList.py
+++ b/linked-list/tests/test_LinkedList.py
@@ -18,6 +18,28 @@ class TestLinkedList(unittest.TestCase):
         # Assert
         self.assertEqual(repr(test_list), "Empty List")
 
+    def test_head(self):
+        # Arrange
+        test_list = LinkedList()
+        test_list.prepend("A")
+
+        # Act
+        head_node = test_list.head()
+
+        # Assert
+        self.assertEqual(head_node.value, "A")
+        self.assertIsNone(head_node.next)
+
+    def test_head_empty_list(self):
+        # Arrange
+        test_list = LinkedList()
+
+        # Act
+        head_node = test_list.head()
+
+        # Assert
+        self.assertIsNone(head_node)
+
     def test_list_is_empty(self):
         # Arrange
         test_list = LinkedList()
@@ -47,7 +69,7 @@ class TestLinkedList(unittest.TestCase):
         # Arrange
         test_list = LinkedList()
         test_list.prepend(5)
-        original_node = test_list.head
+        original_node = test_list._head
 
         # Act
         test_list.prepend(6)
@@ -126,7 +148,7 @@ class TestLinkedList(unittest.TestCase):
     def test_iterating_over_cyclical_list(self):
         # Arrange
         test_list = create_list_from_values(["B", "A"])
-        test_list.head.next.next = test_list.head  # set node "B" next to node "A"
+        test_list._head.next.next = test_list._head  # set node "B" next to node "A"
 
         # Act & Assert
         with self.assertRaises(RuntimeError) as context:
@@ -154,7 +176,7 @@ class TestLinkedList(unittest.TestCase):
         # Arrange
         test_list = create_list_from_values(["G", "F", "E", "D", "C", "B", "A"])
         # traverse list and to get node "B" and node "G"
-        current_node = test_list.head
+        current_node = test_list._head
         while current_node:
             if current_node.value == "B":
                 node_B = current_node
@@ -188,7 +210,7 @@ class TestLinkedList(unittest.TestCase):
         # Arrange
         test_list = LinkedList()
         test_list.prepend("A")
-        test_list.head.next = test_list.head  # set head equal to itself. single node loop
+        test_list._head.next = test_list._head  # set head equal to itself. single node loop
 
         # Act & Assert
         self.assertTrue(test_list.has_cycle())
@@ -203,7 +225,7 @@ class TestLinkedList(unittest.TestCase):
     def test_has_cycle_two_node_list_with_cycle(self):
         # Arrange
         test_list = create_list_from_values(["B", "A"])
-        test_list.head.next.next = test_list.head  # set node "B" next to node "A"
+        test_list._head.next.next = test_list._head  # set node "B" next to node "A"
 
         # Act & Assert
         self.assertTrue(test_list.has_cycle())
@@ -219,7 +241,7 @@ class TestLinkedList(unittest.TestCase):
         # Arrange
         test_list = create_list_from_values(["G", "F", "E", "D", "C", "B", "A"])
         # traverse list and to get node "B" and node "G"
-        current_node = test_list.head
+        current_node = test_list._head
         while current_node:
             if current_node.value == "B":
                 node_b = current_node
@@ -247,7 +269,7 @@ class TestLinkedList(unittest.TestCase):
     def test_find_middle_cyclical_list(self):
         # Arrange
         test_list = create_list_from_values(["B", "A"])
-        test_list.head.next.next = test_list.head  # set node "B" next to node "A"
+        test_list._head.next.next = test_list._head  # set node "B" next to node "A"
 
         # Act & Assert
         with self.assertRaises(RuntimeError) as context:
@@ -308,7 +330,7 @@ class TestLinkedList(unittest.TestCase):
     def test_reverse_cyclical_list(self):
         # Arrange
         test_list = create_list_from_values(["B", "A"])
-        test_list.head.next.next = test_list.head  # set node "B" next to node "A"
+        test_list._head.next.next = test_list._head  # set node "B" next to node "A"
 
         # Act & Assert
         with self.assertRaises(RuntimeError) as context:

--- a/linked-list/tests/test_LinkedList.py
+++ b/linked-list/tests/test_LinkedList.py
@@ -55,6 +55,30 @@ class TestLinkedList(unittest.TestCase):
         # Assert
         self.assertFalse(test_list.is_empty())
 
+    def test_rebuild_index_map(self):
+        # Arrange
+        test_list = create_list_from_values(["D", "C", "B", "A"])
+
+        # Act
+        test_list.rebuild_index_map()
+
+        # Assert
+        self.assertEqual(test_list._index_map[0].value, "A")
+        self.assertEqual(test_list._index_map[1].value, "B")
+        self.assertEqual(test_list._index_map[2].value, "C")
+        self.assertEqual(test_list._index_map[3].value, "D")
+
+    def test_rebuild_index_map_empty_list(self):
+        # Arrange
+        test_list = create_list_from_values([])
+
+        # Act
+        test_list.rebuild_index_map()
+
+        # Assert
+        with self.assertRaises(KeyError) as context:
+            test_list._index_map[0]
+
     def test_prepend_to_empty_list(self):
         # Arrange
         test_list = LinkedList()

--- a/linked-list/tests/test_LinkedList.py
+++ b/linked-list/tests/test_LinkedList.py
@@ -7,6 +7,7 @@ import os
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
 
 from LinkedList import LinkedList
+from Node import Node
 
 
 class TestLinkedList(unittest.TestCase):
@@ -79,6 +80,60 @@ class TestLinkedList(unittest.TestCase):
         with self.assertRaises(KeyError) as context:
             test_list._index_map[0]
 
+    def test__rebuild_index_map_partial(self):
+        # Arrange
+        test_list = create_list_from_values(["C", "B", "A"])
+        node_b = test_list.head().next
+        node_c = node_b.next
+
+        # Act
+        test_list._rebuild_index_map_partial(start_index=1, start_node=node_b)
+
+        # Assert
+        self.assertEqual(test_list._index_map[1], node_b)
+        self.assertEqual(test_list._index_map[2], node_c)
+
+    def test_validate_index_map_valid_map(self):
+        # Arrange
+        test_list = create_list_from_values(["C", "B", "A"])
+        test_list.rebuild_index_map()
+
+        # Act & Assert
+        self.assertTrue(test_list.validate_index_map())
+
+    def test_validate_index_map_stale_index(self):
+        # Arrange
+        test_list = create_list_from_values(["C", "B", "A"])
+        test_list.rebuild_index_map()
+        # pop node_c, but restore it to the index map
+        node_c_value = test_list.pop()
+        test_list._index_map[2] = Node(node_c_value)
+
+        # Act & Assert
+        self.assertFalse(test_list.validate_index_map())
+
+    def test_validate_index_map_incorrect_mapping(self):
+        # Arrange
+        test_list = create_list_from_values(["C", "B", "A"])
+        test_list.rebuild_index_map()
+        node_a = test_list.head()
+        node_b = node_a.next
+        # switch indexes of node_a and node_b
+        test_list._index_map[0] = node_b
+        test_list._index_map[1] = node_a
+
+        # Act & Assert
+        self.assertFalse(test_list.validate_index_map())
+
+    def test_validate_index_map_missing_mapping(self):
+        # Arrange
+        test_list = create_list_from_values(["C", "B", "A"])
+        test_list.rebuild_index_map()
+        test_list._index_map.pop(2)  # get rid of index 2 in the index map
+
+        # Act & Assert
+        self.assertFalse(test_list.validate_index_map())
+
     def test_prepend_to_empty_list(self):
         # Arrange
         test_list = LinkedList()
@@ -93,7 +148,6 @@ class TestLinkedList(unittest.TestCase):
         # Arrange
         test_list = LinkedList()
         test_list.prepend(5)
-        original_node = test_list._head
 
         # Act
         test_list.prepend(6)


### PR DESCRIPTION
### **Summary**
This pull request introduces structural and functional enhancements to the LinkedList class, with a focus on performance, robustness, and documentation clarity. It represents the fourth major iteration in the Linked List Practice Project(#4)

### **Key Changes**
#### Structural Enhancements
- Converted **self.head** to a private attribute (**self._head**) and exposed a public **head()** method for safe access.
- Added a private **self._index_map** dictionary to enable constant-time (O(1)) lookups by index.
- Introduced a **self._list_length** attribute to track list length without traversing.

#### Functional Additions
- Implemented the following public methods:
  - **__len__()** – Returns list length in O(1) time.
  - **__getitem__(index)** – Supports index-based access: my_list[3].
  - **get_node(index)** – Retrieves the node object (not just value) at a given index.
  - **pop()** – Replaces **classic_pop()** with an optimized O(1) implementation using the index map.
- Preserved **classic_pop()** for educational comparison.

#### Internal Methods
- Added private helper methods to manage internal state:
  - **_add_node_to_index_map**, **_remove_node_from_index_map**
  - **_rebuild_index_map_partial**, **_increment_list_length**, **_decrement_list_length**
  - **_update_list_metadata_for_add_node**, **_update_list_metadata_for_remove_node**
- Added **validate_index_map()** for debugging and test validation of index integrity.

### **Testing**
The new features were used across our tests to improve set-up and assertion.

- Tests Added:
  - **head():** 2 tests
  - **rebuild_index_map():** 2 tests
  - **_rebuild_index_map_partial():** 1 test
  - **validate_index_map():** 4 tests
  - **classic_pop():** 4 tests
  - **__getitem__():** 3 tests
  - **get_node():** 3 tests