### PR TITLE
LLPP-0006: Build new features using O(1) index access

### DIFF
--- a/linked-list/DOCUMENTATION.md
+++ b/linked-list/DOCUMENTATION.md
@@ -54,14 +54,9 @@ Initializes an empty linked list with `head` set to `None`.
 ### Attributes:
 These attributes are internally managed and should not be manipulated externally.
 
-##### `self._head`
-The head node of the list. If the list is empty, self._head will be `None`.
-
-##### `self._index_map`
-The map of indexes paired with their corresponding nodes.
-
-##### `self._length`
-The amount of nodes in the list.
+- `self._head`: The head node of the list. If the list is empty, self._head will be `None`.
+- `self._index_map`: The map of indexes paired with their corresponding nodes.
+- `self._length`: The amount of nodes in the list.
 
 ### Dunder Methods:
 

--- a/linked-list/DOCUMENTATION.md
+++ b/linked-list/DOCUMENTATION.md
@@ -131,6 +131,22 @@ ll[2]  # 3
 ```
 ---
 
+###### `__setitem__(index, value)`
+Sets the value of the node at the given index.
+
+###### Examples:
+```python
+ll = LinkedList()
+ll.prepend(3)
+ll.prepend(2)
+ll.prepend(1)
+
+ll[1]  # 2
+ll[1] = 4
+ll[1]  # 4
+```
+---
+
 ### Public Methods:
 These are supported methods to manipulate, analyze, and examine the LinkedList instance. If only public methods are used
 to manipulate the LinkedList, the user can be assured that the list and its metadata will have reliable integrity.
@@ -334,6 +350,59 @@ ll.validate_index_map()  # False
 ```
 ---
 
+##### `insert(index, value)`
+Inserts a new node with the given value at the specified index.
+
+###### Arguments:
+- `index`: (int) The index at which to insert the node.
+- `value`: The value to store in the new node
+
+###### Examples:
+```python
+ll = LinkedList()
+ll.prepend(10)
+ll.prepend(20)
+ll.prepend(30)
+repr(ll)  # LinkedList([30 -> 20 -> 10])
+
+ll.insert(index=2, value=15) # LinkedList([30 -> 20 -> 15 -> 10])
+```
+---
+
+##### `append(value)`
+Removes the node at the specified index.
+
+###### Arguments:
+- `value`: The value to store in the appended node
+
+###### Examples:
+```python
+ll = LinkedList()
+ll.append(10)
+ll.append(20)
+ll.append(30)
+repr(ll)  # LinkedList([10 -> 20 -> 30])
+```
+---
+
+##### `remove(index, value)`
+Removes the node at the specified index.
+
+###### Arguments:
+- `index`: (int) The index at which to remove the node.
+
+###### Examples:
+```python
+ll = LinkedList()
+ll.prepend(10)
+ll.prepend(20)
+ll.prepend(30)
+repr(ll)  # LinkedList([30 -> 20 -> 10])
+
+ll.remove(index=1) # LinkedList([30 -> 10])
+```
+---
+
 #### Private Methods:
 
 ### 🔧 Internal Methods
@@ -354,3 +423,6 @@ Internal counters for maintaining list length.
 
 #### `_update_list_metadata_for_add_node()` / `_update_list_metadata_for_remove_node()`
 Helper methods that bundle together all index map and length updates for adding or removing nodes.
+
+#### `_validate_index()`
+Helper methods that ensures index is an integer and within the bounds. Used to validate index at the start of public methods that take index as an arg.

--- a/linked-list/src/LinkedList.py
+++ b/linked-list/src/LinkedList.py
@@ -381,10 +381,98 @@ class LinkedList:
         Raises:
             IndexError: If the index is out of bounds.
         """
-        if not isinstance(index, int):
-            raise TypeError("Index must be an integer.")
-
         if index < 0 or index >= self._list_length:
             raise IndexError("Index out of bounds.")
 
         return self._index_map[index]
+
+    def __setitem__(self, index: int, value):
+        """
+        Sets the value of the node at the specified index.
+
+        Args:
+            index (int): The index of the node to update.
+            value: The new value to assign to the node.
+
+        Raises:
+            IndexError: If the index is out of bounds.
+        """
+        if isinstance(index, int):
+            raise TypeError
+        if index not in self._index_map:
+            raise IndexError("No node at this index.")
+
+        self._index_map[index].value = value
+
+    def insert(self, index: int, value):
+        """
+        Inserts a new node with the given value at the specified index.
+
+        Args:
+            index (int): The index at which to insert the node.
+            value: The value to store in the new node.
+
+        Raises:
+            IndexError: If the index is out of bounds.
+        """
+        if index == 0:
+            self.prepend(value)
+            return
+        elif index == self._list_length:
+            self.append(value)
+            return
+        elif index < 0 or index > self._list_length:
+            raise IndexError("Index out of bounds.")
+
+        preceding_node = self._index_map[index - 1]
+        node_to_insert = Node(value)
+        subsequent_node = preceding_node.next
+
+        preceding_node.next = node_to_insert
+        node_to_insert.next = subsequent_node
+
+        self._update_list_metadata_for_add_node(index_to_add_node=index, added_node=node_to_insert)
+
+    def append(self, value):
+        """
+        Appends a new node with the given value to the end of the list.
+
+        Args:
+            value: The value to store in the new node.
+        """
+        if self.is_empty():
+            self.prepend(value)
+            return
+
+        node_to_append = Node(value)
+        tail_node = self._index_map[self._list_length - 1]
+
+        tail_node.next = node_to_append
+
+        self._update_list_metadata_for_add_node(index_to_add_node=self._list_length, added_node=node_to_append)
+
+    def remove(self, index: int):
+        """
+        Removes the node at the specified index from the list.
+
+        Args:
+            index (int): The index of the node to remove.
+
+        Raises:
+            IndexError: If the index is out of bounds.
+        """
+        if self.is_empty():
+            raise IndexError("Cannot remove from an empty list.")
+
+        if index not in self._index_map:
+            raise IndexError("No node at this index.")
+
+        if index == 0:
+            self._head = self._head.next
+        else:
+            node_to_remove = self._index_map[index]
+            preceding_node = self._index_map[index - 1]
+            subsequent_node = node_to_remove.next
+            preceding_node.next = subsequent_node
+
+        self._update_list_metadata_for_remove_node(index_of_removed_node=index)

--- a/linked-list/src/LinkedList.py
+++ b/linked-list/src/LinkedList.py
@@ -25,6 +25,25 @@ class LinkedList:
         """
         return self._head is None
 
+    def _validate_index(self, index: int, append_flag: bool = False):
+        """
+        Validates that the index is an integer and within bounds.
+
+        Args:
+            index (int): The index to validate.
+            append_flag (bool): If True, allows index == list_length (e.g., for appending).
+
+        Raises:
+            TypeError: If index is not an integer.
+            IndexError: If index is out of bounds.
+        """
+        if not isinstance(index, int):
+            raise TypeError("Index must be an integer.")
+
+        upper_bound = self._list_length + (1 if append_flag else 0)
+        if index < 0 or index >= upper_bound:
+            raise IndexError("Index out of bounds.")
+
     def rebuild_index_map(self):
         """
         Rebuilds index map from scratch.
@@ -360,11 +379,7 @@ class LinkedList:
         Raises:
             IndexError: If the index is out of bounds.
         """
-        if not isinstance(index, int):
-            raise TypeError("Index must be an integer.")
-
-        if index < 0 or index >= self._list_length:
-            raise IndexError("Index out of bounds.")
+        self._validate_index(index=index)
 
         return self._index_map[index].value
 
@@ -381,8 +396,7 @@ class LinkedList:
         Raises:
             IndexError: If the index is out of bounds.
         """
-        if index < 0 or index >= self._list_length:
-            raise IndexError("Index out of bounds.")
+        self._validate_index(index=index)
 
         return self._index_map[index]
 
@@ -397,10 +411,7 @@ class LinkedList:
         Raises:
             IndexError: If the index is out of bounds.
         """
-        if isinstance(index, int):
-            raise TypeError
-        if index not in self._index_map:
-            raise IndexError("No node at this index.")
+        self._validate_index(index=index)
 
         self._index_map[index].value = value
 
@@ -415,14 +426,14 @@ class LinkedList:
         Raises:
             IndexError: If the index is out of bounds.
         """
+        self._validate_index(index=index, append_flag=True)
+
         if index == 0:
             self.prepend(value)
             return
         elif index == self._list_length:
             self.append(value)
             return
-        elif index < 0 or index > self._list_length:
-            raise IndexError("Index out of bounds.")
 
         preceding_node = self._index_map[index - 1]
         node_to_insert = Node(value)
@@ -464,8 +475,7 @@ class LinkedList:
         if self.is_empty():
             raise IndexError("Cannot remove from an empty list.")
 
-        if index not in self._index_map:
-            raise IndexError("No node at this index.")
+        self._validate_index(index=index)
 
         if index == 0:
             self._head = self._head.next

--- a/linked-list/tests/test_LinkedList.py
+++ b/linked-list/tests/test_LinkedList.py
@@ -518,6 +518,64 @@ class TestLinkedList(unittest.TestCase):
         # Assert
         self.assertEqual(result, node_a)
 
+    def test_validate_index_valid_no_append_flag(self):
+        # Arrange
+        test_list = create_list_from_values(["D", "C", "B", "A"])
+
+        # Act & Assert
+        for index in range(4):
+            test_list._validate_index(index)
+        # none of the indexes should raise
+
+    def test_validate_index_valid_append_flag(self):
+        # Arrange
+        test_list = create_list_from_values(["D", "C", "B", "A"])
+
+        # Act & Assert
+        for index in range(5):
+            test_list._validate_index(index, True)
+        # none of the indexes should raise
+
+    def test_validate_index_invalid_type(self):
+        # Arrange
+        test_list = create_list_from_values(["D", "C", "B", "A"])
+
+        # Act & Assert
+        with self.assertRaises(TypeError) as context:
+            test_list._validate_index("A")
+
+        self.assertEqual(str(context.exception), "Index must be an integer.")
+
+    def test_validate_index_negative_index(self):
+        # Arrange
+        test_list = create_list_from_values(["D", "C", "B", "A"])
+
+        # Act & Assert
+        with self.assertRaises(IndexError) as context:
+            test_list._validate_index(-1)
+
+        self.assertEqual(str(context.exception), "Index out of bounds.")
+
+    def test_validate_index_too_high_index_no_append(self):
+        # Arrange
+        test_list = create_list_from_values(["D", "C", "B", "A"])
+
+        # Act & Assert
+        with self.assertRaises(IndexError) as context:
+            test_list._validate_index(4)
+
+        self.assertEqual(str(context.exception), "Index out of bounds.")
+
+    def test_validate_index_too_high_index_append(self):
+        # Arrange
+        test_list = create_list_from_values(["D", "C", "B", "A"])
+
+        # Act & Assert
+        with self.assertRaises(IndexError) as context:
+            test_list._validate_index(5)
+
+        self.assertEqual(str(context.exception), "Index out of bounds.")
+
 ###### HELPER FUNCTIONS ######
 def create_list_from_values(values):
     linked_list = LinkedList()

--- a/linked-list/tests/test_LinkedList.py
+++ b/linked-list/tests/test_LinkedList.py
@@ -576,6 +576,148 @@ class TestLinkedList(unittest.TestCase):
 
         self.assertEqual(str(context.exception), "Index out of bounds.")
 
+    def test_insert_at_head(self):
+        # Arrange
+        test_list = create_list_from_values(["D", "C", "B", "A"])
+
+        # Act
+        test_list.insert(index=0, value="test")
+
+        # Assert
+        self.assertEqual(repr(test_list), "LinkedList([test -> A -> B -> C -> D])")
+        self.assertTrue(test_list.validate_index_map())
+        self.assertEqual(len(test_list), 5)
+
+    def test_insert_at_middle(self):
+        # Arrange
+        test_list = create_list_from_values(["D", "C", "B", "A"])
+
+        # Act
+        test_list.insert(index=1, value="test")
+
+        # Assert
+        self.assertEqual(repr(test_list), "LinkedList([A -> test -> B -> C -> D])")
+        self.assertTrue(test_list.validate_index_map())
+        self.assertEqual(len(test_list), 5)
+
+    def test_insert_at_tail(self):
+        # Arrange
+        test_list = create_list_from_values(["D", "C", "B", "A"])
+
+        # Act
+        test_list.insert(index=3, value="test")
+
+        # Assert
+        self.assertEqual(repr(test_list), "LinkedList([A -> B -> C -> test -> D])")
+        self.assertTrue(test_list.validate_index_map())
+        self.assertEqual(len(test_list), 5)
+
+    def test_insert_after_tail(self):
+        # Arrange
+        test_list = create_list_from_values(["D", "C", "B", "A"])
+
+        # Act
+        test_list.insert(index=4, value="test")
+
+        # Assert
+        self.assertEqual(repr(test_list), "LinkedList([A -> B -> C -> D -> test])")
+        self.assertTrue(test_list.validate_index_map())
+        self.assertEqual(len(test_list), 5)
+
+    def test_insert_empty_list(self):
+        # Arrange
+        test_list = create_list_from_values([])
+
+        # Act
+        test_list.insert(index=0, value="test")
+
+        # Assert
+        self.assertEqual(repr(test_list), "LinkedList([test])")
+        self.assertTrue(test_list.validate_index_map())
+        self.assertEqual(len(test_list), 1)
+
+    def test_remove_head(self):
+        # Arrange
+        test_list = create_list_from_values(["D", "C", "B", "A"])
+
+        # Act
+        test_list.remove(index=0)
+
+        # Assert
+        self.assertEqual(repr(test_list), "LinkedList([B -> C -> D])")
+        self.assertTrue(test_list.validate_index_map())
+        self.assertEqual(len(test_list), 3)
+
+    def test_remove_middle_node(self):
+        # Arrange
+        test_list = create_list_from_values(["D", "C", "B", "A"])
+
+        # Act
+        test_list.remove(index=1)
+
+        # Assert
+        self.assertEqual(repr(test_list), "LinkedList([A -> C -> D])")
+        self.assertTrue(test_list.validate_index_map())
+        self.assertEqual(len(test_list), 3)
+
+    def test_remove_tail(self):
+        # Arrange
+        test_list = create_list_from_values(["D", "C", "B", "A"])
+
+        # Act
+        test_list.remove(index=3)
+
+        # Assert
+        self.assertEqual(repr(test_list), "LinkedList([A -> B -> C])")
+        self.assertTrue(test_list.validate_index_map())
+        self.assertEqual(len(test_list), 3)
+
+    def test_remove_from_empty_list(self):
+        # Arrange
+        test_list = create_list_from_values([])
+
+        # Act & Assert
+        with self.assertRaises(IndexError) as context:
+            test_list.remove(index=0)
+
+        self.assertEqual(str(context.exception), "Cannot remove from an empty list.")
+
+    def test_setitem(self):
+        # Arrange
+        test_list = create_list_from_values(["D", "C", "B", "A"])
+
+        # Act
+        test_list[1] = "new value"
+
+        # Assert
+        self.assertEqual(repr(test_list), "LinkedList([A -> new value -> C -> D])")
+        self.assertTrue(test_list.validate_index_map())
+        self.assertEqual(len(test_list), 4)
+
+    def test_append(self):
+        # Arrange
+        test_list = create_list_from_values(["D", "C", "B", "A"])
+
+        # Act
+        test_list.append("test")
+
+        # Assert
+        self.assertEqual(repr(test_list), "LinkedList([A -> B -> C -> D -> test])")
+        self.assertTrue(test_list.validate_index_map())
+        self.assertEqual(len(test_list), 5)
+
+    def test_append_empty_list(self):
+        # Arrange
+        test_list = create_list_from_values([])
+
+        # Act
+        test_list.append("test")
+
+        # Assert
+        self.assertEqual(repr(test_list), "LinkedList([test])")
+        self.assertTrue(test_list.validate_index_map())
+        self.assertEqual(len(test_list), 1)
+
 ###### HELPER FUNCTIONS ######
 def create_list_from_values(values):
     linked_list = LinkedList()


### PR DESCRIPTION
### **Summary**
This PR adds new mutating methods to the LinkedList class, enabling indexed insertion, assignment, and deletion operations. These changes leverage the internal _index_map to support efficient positional access and modification. It represents the fifth major iteration in the Linked List Practice Project(#6)

### **Key Changes**
#### Method Additions
- Implemented the following public methods:
  - **__setitem__(index, value)** – Allows assignment to a node by index (ll[index] = value)
  - **insert(index, value)** – Inserts a node at a specified index
  - **append(value)** – Appends a node to the end of the list (optimized for indexed access)
  - **remove(index)** – Removes a node at a specified index
- Preserved **classic_pop()** for educational comparison.

#### Internal Methods
- Added private helper methods to _validate_index(index, append_flag=False):
 - Ensures index is an integer
  - Verifies bounds (with special handling for **append**)
  - Replaced manual index checks in multiple methods

### **Testing**
The new features were used across our tests to improve set-up and assertion.

- Tests Added:
  - **__setitem__():** 1 test
  - **insert():** 5 tests
  - **append():** 2 tests
  - **remove():** 4 tests
  - **_validate_index():** 6 tests

### **Design Notes**

- **_validate_index()** centralizes error handling and enforces consistent behavior across all index-based operations.
- Appending to an empty list now correctly falls back to prepend() to maintain list invariants.
- Return values were intentionally omitted from validator methods to keep the focus on enforcing correctness via exceptions.