### PR TITLE
HEAP-0003: Implement peek to return the smallest element

### DIFF
--- a/heap/heap.md
+++ b/heap/heap.md
@@ -67,6 +67,21 @@ heap.insert(1)
 print(heap._data) # Output: [1, 5, 15, 22, 20]
 ```
 ---
+### `.peek()`
+Returns the smallest element of the list without removing
+
+### Example
+```python
+heap = Heap()
+heap.insert(20)
+heap.insert(5)
+heap.insert(15)
+heap.insert(22)
+heap.insert(1)
+
+print(heap.peek()) # Output: 1
+```
+---
 ## Private Methods
 - `_bubble_up(index)`
   - Bubble up (aka Sift Up or Percolate Up) is the process of restoring the min-heap property after a new element is added to the heap

--- a/heap/heap.md
+++ b/heap/heap.md
@@ -68,11 +68,14 @@ print(heap._data) # Output: [1, 5, 15, 22, 20]
 ```
 ---
 ### `.peek()`
-Returns the smallest element of the list without removing
+Returns the smallest element of the heap without removing
 
 ### Example
 ```python
 heap = Heap()
+
+print(heap().peek()) # Output: None
+
 heap.insert(20)
 heap.insert(5)
 heap.insert(15)

--- a/heap/src/heap.py
+++ b/heap/src/heap.py
@@ -32,10 +32,10 @@ class Heap:
 
     def peek(self):
         """
-        Return the smallest element in the heap without removing it
+        Return the smallest element in the heap without removing it.
 
-        Return
-            root: the value of the smallest element of the heap
+        Returns:
+            The value of the smallest element (the root), or None if the heap is empty.
         """
 
         if not self._data:

--- a/heap/src/heap.py
+++ b/heap/src/heap.py
@@ -30,3 +30,16 @@ class Heap:
             # calculate the new parent_index
             parent_index = (index - 1) // 2
 
+    def peek(self):
+        """
+        Return the smallest element in the heap without removing it
+
+        Return
+            root: the value of the smallest element of the heap
+        """
+
+        if not self._data:
+            return None
+
+        return self._data[0]
+

--- a/heap/tests/test_Heap.py
+++ b/heap/tests/test_Heap.py
@@ -88,7 +88,7 @@ class TestHeapInsert(unittest.TestCase):
         # Assert
         self.assertEqual(1, smallest_value)
 
-    def test_peek_multiple_element(self):
+    def test_peek_multiple_elements(self):
         # Arrange
         heap = Heap()
         values = [20, 5, 15, 22, 1]
@@ -100,6 +100,19 @@ class TestHeapInsert(unittest.TestCase):
 
         # Assert
         self.assertEqual(1, smallest_value)
+
+    def test_peek_does_not_remove_element(self):
+        # Arrange
+        heap = Heap()
+        heap.insert(3)
+        peeked = heap.peek()
+
+        # Act
+        still_peeked = heap.peek()
+
+        # Assert
+        self.assertEqual(peeked, still_peeked)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/heap/tests/test_Heap.py
+++ b/heap/tests/test_Heap.py
@@ -19,7 +19,7 @@ class TestHeapInsert(unittest.TestCase):
         heap.insert(10)
 
         # Assert
-        self.assertEqual(heap._data, [10])
+        self.assertEqual([10], heap._data)
 
     def test_insert_multiple_values_maintains_min_heap(self):
         # Arrange
@@ -32,18 +32,16 @@ class TestHeapInsert(unittest.TestCase):
 
         # Assert
         # The smallest value should bubble up to index 0
-        self.assertEqual(heap._data[0], min(values))
+        self.assertEqual(min(values), heap._data[0])
 
     def test_insert_maintains_order_for_heap_property(self):
         # Arrange
         heap = Heap()
+        values = [20, 5, 15, 22, 1]
 
         # Act
-        heap.insert(20)
-        heap.insert(5)
-        heap.insert(15)
-        heap.insert(22)
-        heap.insert(1)
+        for val in values:
+            heap.insert(val)
 
         # Assert
         # Check that the heap property holds at each parent node
@@ -66,9 +64,42 @@ class TestHeapInsert(unittest.TestCase):
             heap.insert(val)
 
         # Assert
-        self.assertEqual(heap._data[0], 2)
-        self.assertEqual(sorted(heap._data), sorted(values))
+        self.assertEqual(2, heap._data[0])
+        self.assertEqual(sorted(values), sorted(heap._data))
 
+    def test_peek_empty_heap(self):
+        # Arrange
+        heap = Heap()
+
+        # Act
+        smallest_value = heap.peek()
+
+        # Assert
+        self.assertIsNone(smallest_value)
+
+    def test_peek_single_element(self):
+        # Arrange
+        heap = Heap()
+        heap.insert(1)
+
+        # Act
+        smallest_value = heap.peek()
+
+        # Assert
+        self.assertEqual(1, smallest_value)
+
+    def test_peek_multiple_element(self):
+        # Arrange
+        heap = Heap()
+        values = [20, 5, 15, 22, 1]
+        for val in values:
+            heap.insert(val)
+
+        # Act
+        smallest_value = heap.peek()
+
+        # Assert
+        self.assertEqual(1, smallest_value)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Summary

This PR implements the `peek()` method for the `Heap` class. The method allows users to retrieve the smallest element in the heap without removing it. This is a common operation in heap-based data structures and supports efficient read-only access to the root.

### Changes

- Added `peek()` method to the `Heap` class.
  - Returns the root element (smallest value).
  - Returns `None` if the heap is empty.
- Updated class documentation to include `.peek()` usage.
- Added unit tests:
  - ✅ `test_peek_empty_heap`: returns `None` when heap is empty
  - ✅ `test_peek_single_element`: returns the inserted value
  - ✅ `test_peek_multiple_elements`: returns the correct root after multiple insertions
  - ✅ `test_peek_does_not_remove_element`: confirms that peeking does not remove the element

### Example Usage

```python
heap = Heap()
heap.insert(20)
heap.insert(5)
heap.insert(15)
heap.insert(22)
heap.insert(1)

print(heap.peek())  # Output: 1
```