### PR TITLE
HEAP-0004: Implement remove to extract the smallest element

### DIFF
--- a/heap/README.md
+++ b/heap/README.md
@@ -27,7 +27,7 @@ print(heap._data)  # []
 
 ## Development Plan
 1. ✅ Initialize the Heap class with an empty internal container.
-2. ⏳ Add basic heap operations (insert, extract_min, peek, etc.).
+2. ⏳ Add basic heap operations (push, pop, peek, etc.).
 3. ⏳ Add internal helper methods (e.g., _heapify_up, _heapify_down).
 4. ⏳ Add support for max-heap toggle
 5. ⏳ Benchmark against heapq

--- a/heap/heap.md
+++ b/heap/heap.md
@@ -52,17 +52,17 @@ This scheme aligns with how Python lists naturally operate. By indexing in this 
 ---
 ## Public Methods
 
-### `.insert(value)`
-Inserts value into the heap and places it in its rightful spot
+### `.push(value)`
+Pushes value into the heap and places it in its rightful spot
 
 ### Example
 ```python
 heap = Heap()
-heap.insert(20)
-heap.insert(5)
-heap.insert(15)
-heap.insert(22)
-heap.insert(1)
+heap.push(20)
+heap.push(5)
+heap.push(15)
+heap.push(22)
+heap.push(1)
 
 print(heap._data) # Output: [1, 5, 15, 22, 20]
 ```
@@ -76,29 +76,80 @@ heap = Heap()
 
 print(heap().peek()) # Output: None
 
-heap.insert(20)
-heap.insert(5)
-heap.insert(15)
-heap.insert(22)
-heap.insert(1)
+heap.push(20)
+heap.push(5)
+heap.push(15)
+heap.push(22)
+heap.push(1)
 
 print(heap.peek()) # Output: 1
 ```
 ---
+
+### `.pop()`
+Removes the minimum element from the heap, returns its value, and restores min-heap property.
+
+### Example
+```python
+heap = Heap()
+heap.push(20)
+heap.push(5)
+heap.push(15)
+heap.push(22)
+heap.push(1)
+
+print(heap._data) # Output: [1, 5, 15, 22, 20]
+print(heap.pop()) # Output: 1
+print(heap._data) # Output: [5, 20, 15, 22]
+```
+---
+
 ## Private Methods
-- `_bubble_up(index)`
-  - Bubble up (aka Sift Up or Percolate Up) is the process of restoring the min-heap property after a new element is added to the heap
-  - When a new value is inserted, it is initially placed at the end of the internal list (which corresponds to the next available leaf position of the binary tree representation). However, this new value might violate the heap property by being smaller than its parent.
-  - To fix this, the value is repeatedly compared to its parent, and if it's smaller, the two are swapped. This continues until:
-    - The value is no longer smaller than its parent, or
-    - It reaches the root of the heap
-  - This process ensures that the smallest value "bubbles up" toward the top, preserving the min-heap invariant: **Every parent node is less than or equal to its children**
+
+`_bubble_up(index)`
+- Bubble up (aka Sift Up or Percolate Up) is the process of restoring the min-heap property after a new element is added to the heap
+- When a new value is pushed, it is initially placed at the end of the internal list (which corresponds to the next available leaf position of the binary tree representation). However, this new value might violate the heap property by being smaller than its parent.
+- To fix this, the value is repeatedly compared to its parent, and if it's smaller, the two are swapped. This continues until:
+  - The value is no longer smaller than its parent, or
+  - It reaches the root of the heap
+- This process ensures that the smallest value "bubbles up" toward the top, preserving the min-heap invariant: **Every parent node is less than or equal to its children**
+
+`._bubble_down(index)`
+- Bubble down (aka Sift Down or Percolate Down) is the process of restoring the min-heap property after the root element is removed or replaced.
+    - When the root (or any internal node) is out of place — typically because the last element was moved to the root position — it may violate the heap property by being greater than one or both of its children.
+    - To fix this, the value is repeatedly compared to its children, and if it is greater than either, it is swapped with the smaller child. This continues until:
+      - The value is no longer greater than either of its children, or
+      - It reaches a leaf node (i.e., has no children)
+    - This process ensures that the smallest values "sink down" toward the leaves, preserving the min-heap invariant: **Every parent node is less than or equal to its children**
 
 ## Development Notes
 
 - This is a **min-heap** by default.
 - `_data` is currently a public-facing attribute for transparency during development.
 - A full API will eventually abstract away direct access to `_data`.
+
+## Lessons Learned
+
+### "Stack-Safe"
+When creating the private ._bubble_down(index) method, ChatGPT brought a term to my attention: stack-safe. It refers to the danger of recursive functions causing stack overflows.
+The stack refers to the call stack or "the runtime memory that tracks function calls". Each function call has a frame which gives us a helpful visual for recursive functions.
+Each recursion creates a layer or a frame. The first recursion leads to the next which leads to the next which eventually leads to the final recursion. Once the final recursion is resolved,
+the penultimate recursion can be resolved, and the recursion before that and before that until we get back to the first recursion and resolve it.
+
+Previously, I was thinking of recursion as a winding and then an unwinding. There is actually a video of a brick wall being built, and the top row of bricks have been set up like dominoes.
+The first brick is tipped and knocks into the next one which knocks into the next one. The first brick is resting on the second brick which is then resting on the third, so on and so forth.
+Once the last brick is tipped, it is allowed to fall over flat (with no subsequent brick to prop it up), this allows all the previous bricks to also fall flat.
+
+Anyway, this seems to be a very good physical representation of a recursive function.
+Here is a [link](https://www.reddit.com/r/oddlysatisfying/comments/etunfx/the_way_these_bricks_fall_into_place/) to a reddit post of a video of this phenomenon.
+
+Further observations:
+- python has a call stack frame limit of ~1,000 frames
+- nested functions also use the call stack, but obviously carry much lower risk of stack overflow than recursion.
+- each frame stores:
+  - local variables
+  - the return address
+  - arguments
 
 ---
 

--- a/heap/src/heap.py
+++ b/heap/src/heap.py
@@ -2,9 +2,9 @@ class Heap:
     def __init__(self):
         self._data = []
 
-    def insert(self, value):
+    def push(self, value):
         """
-        Inserts value into the heap and places it in its rightful spot
+        Pushes value into the heap and places it in its rightful spot
 
         Args
             value: the value to place in the heap
@@ -43,3 +43,51 @@ class Heap:
 
         return self._data[0]
 
+    def pop(self):
+        """
+        Remove and return the root element of the heap
+
+        Notes:
+            This is accomplished optimally by swapping the root element with the last element of our list binary tree
+            representation. Then, since the root element is now in the final spot, we can perform a native list .pop().
+            After the root element has been popped, we bubble down the new root element (previously the last element).
+            By comparing the new root to its children and swapping with the smallest child, we restore the min-heap
+            property.
+        """
+        if not self._data:
+            return None
+
+        # Swap the root element and the last element
+        last_index = len(self._data) - 1
+        self._data[0], self._data[last_index] = self._data[last_index], self._data[0]
+
+        # Remove the min element and save the value
+        min_element_value = self._data.pop()
+
+        # Bubble down the new root element to restore min-heap property
+        self._bubble_down(0)
+
+        return min_element_value
+
+    def _bubble_down(self, index):
+        if not self._data:
+            return
+
+        heap_length = len(self._data)
+
+        while index < heap_length:
+            left = index * 2 + 1
+            right = index * 2 + 2
+            smallest = index
+
+            if left < heap_length and self._data[left] < self._data[smallest]:
+                smallest = left
+
+            if right < heap_length and self._data[right] < self._data[smallest]:
+                smallest = right
+
+            if smallest == index:
+                break
+
+            self._data[index], self._data[smallest] = self._data[smallest], self._data[index]
+            index = smallest

--- a/heap/tests/test_Heap.py
+++ b/heap/tests/test_Heap.py
@@ -9,39 +9,39 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../s
 from heap import Heap
 
 
-class TestHeapInsert(unittest.TestCase):
+class TestHeap(unittest.TestCase):
 
-    def test_insert_single_value(self):
+    def test_push_single_value(self):
         # Arrange
         heap = Heap()
 
         # Act
-        heap.insert(10)
+        heap.push(10)
 
         # Assert
         self.assertEqual([10], heap._data)
 
-    def test_insert_multiple_values_maintains_min_heap(self):
+    def test_push_multiple_values_maintains_min_heap(self):
         # Arrange
         heap = Heap()
         values = [10, 4, 7, 2, 8]
 
         # Act
         for val in values:
-            heap.insert(val)
+            heap.push(val)
 
         # Assert
         # The smallest value should bubble up to index 0
         self.assertEqual(min(values), heap._data[0])
 
-    def test_insert_maintains_order_for_heap_property(self):
+    def test_push_maintains_order_for_heap_property(self):
         # Arrange
         heap = Heap()
         values = [20, 5, 15, 22, 1]
 
         # Act
         for val in values:
-            heap.insert(val)
+            heap.push(val)
 
         # Assert
         # Check that the heap property holds at each parent node
@@ -54,14 +54,14 @@ class TestHeapInsert(unittest.TestCase):
             if right < len(data):
                 self.assertLessEqual(data[i], data[right])
 
-    def test_insert_duplicate_values(self):
+    def test_push_duplicate_values(self):
         # Arrange
         heap = Heap()
         values = [5, 3, 3, 5, 2]
 
         # Act
         for val in values:
-            heap.insert(val)
+            heap.push(val)
 
         # Assert
         self.assertEqual(2, heap._data[0])
@@ -80,7 +80,7 @@ class TestHeapInsert(unittest.TestCase):
     def test_peek_single_element(self):
         # Arrange
         heap = Heap()
-        heap.insert(1)
+        heap.push(1)
 
         # Act
         smallest_value = heap.peek()
@@ -93,7 +93,7 @@ class TestHeapInsert(unittest.TestCase):
         heap = Heap()
         values = [20, 5, 15, 22, 1]
         for val in values:
-            heap.insert(val)
+            heap.push(val)
 
         # Act
         smallest_value = heap.peek()
@@ -104,7 +104,7 @@ class TestHeapInsert(unittest.TestCase):
     def test_peek_does_not_remove_element(self):
         # Arrange
         heap = Heap()
-        heap.insert(3)
+        heap.push(3)
         peeked = heap.peek()
 
         # Act
@@ -112,6 +112,71 @@ class TestHeapInsert(unittest.TestCase):
 
         # Assert
         self.assertEqual(peeked, still_peeked)
+
+    def test_pop_returns_smallest(self):
+        # Arrange
+        heap = Heap()
+        for value in [5, 3, 8, 1, 4]:
+            heap.push(value)
+
+        # Act
+        result = heap.pop()
+
+        # Assert
+        self.assertEqual(result, 1)
+
+    def test_pop_multiple_times_returns_sorted_values(self):
+        # Arrange
+        heap = Heap()
+        for value in [5, 3, 8, 1, 4]:
+            heap.push(value)
+
+        # Act
+        popped_values = [heap.pop() for _ in range(5)]
+
+        # Assert
+        self.assertEqual(popped_values, [1, 3, 4, 5, 8])
+
+    def test_pop_on_empty_heap_returns_none(self):
+        # Arrange
+        heap = Heap()
+
+        # Act
+        result = heap.pop()
+
+        # Assert
+        self.assertIsNone(result)
+
+    def test_heap_property_after_pop(self):
+        # Arrange
+        heap = Heap()
+        for value in [5, 3, 8, 1, 4]:
+            heap.push(value)
+
+        # Act
+        heap.pop()
+
+        # Assert
+        for i in range(len(heap._data) // 2):
+            left = 2 * i + 1
+            right = 2 * i + 2
+            if left < len(heap._data):
+                self.assertLessEqual(heap._data[i], heap._data[left])
+            if right < len(heap._data):
+                self.assertLessEqual(heap._data[i], heap._data[right])
+
+    def test_pop_single_element_then_empty(self):
+        # Arrange
+        heap = Heap()
+        heap.push(10)
+
+        # Act
+        first_pop = heap.pop()
+        second_pop = heap.pop()
+
+        # Assert
+        self.assertEqual(first_pop, 10)
+        self.assertIsNone(second_pop)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Summary
This PR introduces the `pop` method to the `Heap` class, ensuring that elements can now be removed from the top of the heap while maintaining heap structure via a `_bubble_down` operation. Additionally, five new unit tests have been added to validate core pop behavior, and project documentation has been meaningfully updated.

### Changes
- Implemented the `pop` method:
  - Removes the root element and re-establishes heap order using a `_bubble_down` helper.
- Added `_bubble_down(index)` method.
- Added five unit tests
- Updated `README.md` and `heap.md`
- Re-named `.insert(value)` to `.push(value)`