### PR TITLE
HEAP-0006: Add support for both min-heap and max-heap via a flag

### DIFF
--- a/heap/README.md
+++ b/heap/README.md
@@ -1,8 +1,8 @@
 # Heap Data Structure in Python
-This project implements a **min-heap** in Python, starting with a basic class structure and gradually building functionality via development tickets.
+This project implements a **min-heap** or **max-heap** in Python, starting with a basic class structure and gradually building functionality via development tickets.
 
 ## Features
-- Min-heap implementation using a Python list as the internal data container.
+- Heap implementation using a Python list as the internal data container.
 - Simple, testable structure with iterative enhancements.
 
 ## Getting Started
@@ -29,7 +29,7 @@ print(heap._data)  # []
 1. ✅ Initialize the Heap class with an empty internal container.
 2. ✅ Add basic heap operations (push, pop, peek, etc.).
 3. ✅ Add internal helper methods (e.g., _heapify_up, _heapify_down).
-4. ⏳ Add support for max-heap toggle
+4. ✅ Add support for max-heap toggle
 5. ⏳ Benchmark against heapq
 
 ## Documentation

--- a/heap/heap.md
+++ b/heap/heap.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The `Heap` class implements a min-heap using a Python list as the internal data container. This version initializes a list of values as a heap and provides heap operations.
+The `Heap` class implements a min-heap or max heap using a Python list as the internal data container. This version initializes a list of values as a heap and provides heap operations.
 
 The heap uses **0-based indexing** for internal structure.
 
@@ -13,8 +13,15 @@ The heap uses **0-based indexing** for internal structure.
 ### Constructor
 
 ```python
-def __init__(self, list_of_values=None):
+def __init__(self, list_of_values=None, max_heap=False):
     self._data = list(list_of_values) if list_of_values is not None else []
+    
+    if max_heap:
+        self._min_max_multiplier = -1
+        self._data = [-element for element in self._data]
+    else:
+        self._min_max_multiplier = 1
+    
     self._heapify()
 ```
 ---
@@ -27,19 +34,25 @@ from heap import Heap
 empty_heap = Heap()
 print(empty_heap._data)  # Output: []
 
-populated_heap = Heap([3, 7, 1, 5, 10])
-print(populated_heap._data) # Output: [1, 5, 3, 7, 10]
+min_heap = Heap([3, 7, 1, 5, 10])
+print(min_heap._data) # Output: [1, 5, 3, 7, 10]
+
+max_heap = Heap(list_of_values=[3, 7, 1, 5, 10], max_heap=True)
+print(max_heap._data) # Output: [-10, -7, -1, -5, -3]
 ```
 ---
 
 ## Private Attributes
 
 ### `_data`
-
 - **Type**: `list`
 - **Description**: Stores the elements of the heap.
 - **Initial Value**: An empty list.
 
+### `_min_max_multiplier`
+- **Type**: `boolean`
+- **Description**: The value for each ingested or outputted value to be multiplied by
+- **Initial Value**: `False`.
 ---
 
 ## Indexing Scheme
@@ -99,6 +112,33 @@ heap = Heap([20, 5, 15, 22, 1])
 print(heap._data) # Output: [1, 5, 15, 22, 20]
 print(heap.pop()) # Output: 1
 print(heap._data) # Output: [5, 20, 15, 22]
+```
+---
+
+### `.is_min_heap()`
+Returns True if this heap is a min-heap, False if it is a max-heap
+
+### Example
+```python
+max_heap = Heap(list_of_values=[1], max_heap=True)
+print(max_heap.is_min_heap()) # False
+
+min_heap = Heap(list_of_values=[1], max_heap=False)
+print(min_heap.is_min_heap()) # True
+```
+---
+
+
+### `.toggle_heap_type()`
+Converts this heap to its opposite heap type (min-heap to max-heap and vice versa). All internal values are inverted and the heap property is restored
+
+### Example
+```python
+heap = Heap(list_of_values=[1, 4, 5], max_heap=False)
+print(heap._data) # Output: [1, 4, 5]
+
+heap.toggle_heap_type()
+print(heap._data) # Output: [-5, -4, -1]
 ```
 ---
 
@@ -172,14 +212,38 @@ At the moment of the function definition, the mutable default list is created. I
 
 Mutable refers to anything that can be changed in place. E.g. `list`, `dict`, `set`, `bytearray`
 
+### DOWN GOES `unittest`! DOWN GOES `unittest`!
+The late Howard Cosell was shouting in my ear as `unittest` hit the canvas. In implementing the max-heap capability for this heap class I realized that I would need to essentially double up my unit test since nearly every operation needs a set of tests for a min-heap and for a max-heap.
+The clean way to accomplish this is through parameterization, or having your tests run twice: once for min-heap, once for max-heap. And `unittest`'s options for accomplishing this were ugly and verbose.
+```python
+import unittest
+
+class TestHeap(unittest.TestCase):
+    def test_pop(self):
+        for max_heap, expected in [(False, [1, 2, 3]), (True, [3, 2, 1])]:
+            with self.subTest(max_heap=max_heap):
+                heap = Heap(list_of_values=[3, 1, 2], max_heap=max_heap)
+                result = [heap.pop() for _ in range(3)]
+                self.assertEqual(expected, result)
+```
+That is just the grossest thing I have ever seen(dramatic). Where do I put my "Arrange-Act-Assert"?! There is nothing glaringly wrong; it's just bad feng shui.
+Here is how it is done using parameters in `pytest`:
+```python
+import pytest
+
+@pytest.mark.parametrize("max_heap", [True, False])
+def test_pop(max_heap):
+    # Arrange
+    heap = Heap(list_of_values=[3, 1, 2], max_heap=max_heap)
+    expected = [3, 2, 1] if max_heap else [1, 2, 3]
+    
+    # Act
+    results = [heap.pop() for _ in range(3)]
+    
+    # Assert
+    assert results == expected
+```
+This version is so much cleaner in my opinion and I find that to be important enough to me to make the switch to `pytest`, which
+is apparently the more serious unit testing python library anyway. As a result this class will feature a full test suite in `pytest`.
 ---
 
-## Future Roadmap
-
-The class will expand to support:
-
-- `extract_min()`
-- `peek()`
-- Internal reheapification (`_heapify_up`, `_heapify_down`)
-- Optional max-heap toggle
-- Input validation and robust error handling

--- a/heap/src/heap.py
+++ b/heap/src/heap.py
@@ -1,6 +1,11 @@
 class Heap:
-    def __init__(self, list_of_values=None):
+    def __init__(self, list_of_values=None, max_heap=False):
         self._data = list(list_of_values) if list_of_values is not None else []
+        if max_heap:
+            self.min_max_multiplier = -1
+            self._data = [-element for element in self._data]
+        else:
+            self.min_max_multiplier = 1
         self._heapify()
 
     def push(self, value):
@@ -10,6 +15,8 @@ class Heap:
         Args
             value: the value to place in the heap
         """
+        # adjust value based on max_heap flag
+        value = self.min_max_multiplier * value
 
         # append the value to the end of the list
         self._data.append(value)
@@ -42,7 +49,7 @@ class Heap:
         if not self._data:
             return None
 
-        return self._data[0]
+        return self.min_max_multiplier * self._data[0]
 
     def pop(self):
         """
@@ -68,7 +75,7 @@ class Heap:
         # Bubble down the new root element to restore min-heap property
         self._bubble_down(0)
 
-        return min_element_value
+        return self.min_max_multiplier * min_element_value
 
     def _bubble_down(self, index):
         if not self._data:

--- a/heap/src/heap.py
+++ b/heap/src/heap.py
@@ -2,10 +2,10 @@ class Heap:
     def __init__(self, list_of_values=None, max_heap=False):
         self._data = list(list_of_values) if list_of_values is not None else []
         if max_heap:
-            self.min_max_multiplier = -1
+            self._min_max_multiplier = -1
             self._data = [-element for element in self._data]
         else:
-            self.min_max_multiplier = 1
+            self._min_max_multiplier = 1
         self._heapify()
 
     def push(self, value):
@@ -16,7 +16,7 @@ class Heap:
             value: the value to place in the heap
         """
         # adjust value based on max_heap flag
-        value = self.min_max_multiplier * value
+        value = self._min_max_multiplier * value
 
         # append the value to the end of the list
         self._data.append(value)
@@ -49,7 +49,7 @@ class Heap:
         if not self._data:
             return None
 
-        return self.min_max_multiplier * self._data[0]
+        return self._min_max_multiplier * self._data[0]
 
     def pop(self):
         """
@@ -75,7 +75,7 @@ class Heap:
         # Bubble down the new root element to restore min-heap property
         self._bubble_down(0)
 
-        return self.min_max_multiplier * min_element_value
+        return self._min_max_multiplier * min_element_value
 
     def _bubble_down(self, index):
         if not self._data:
@@ -109,3 +109,18 @@ class Heap:
 
         for index in reversed(range(last_parent + 1)):
             self._bubble_down(index)
+
+    def is_min_heap(self):
+        """
+        Returns True if this heap is a min-heap, False if it is a max-heap
+        """
+        return self._min_max_multiplier == 1
+
+    def toggle_heap_type(self):
+        """
+        Converts this heap to its opposite heap type (min-heap to max-heap and vice versa). All internal values are
+        inverted and the heap property is restored
+        """
+        self._min_max_multiplier *= -1
+        self._data = [-element for element in self._data]
+        self._heapify()

--- a/heap/src/heap.py
+++ b/heap/src/heap.py
@@ -1,11 +1,16 @@
 class Heap:
     def __init__(self, list_of_values=None, max_heap=False):
+        # handle incoming data
         self._data = list(list_of_values) if list_of_values is not None else []
+
+        # set min-heap or max-heap property
         if max_heap:
             self._min_max_multiplier = -1
             self._data = [-element for element in self._data]
         else:
             self._min_max_multiplier = 1
+
+        # heapify incoming data
         self._heapify()
 
     def push(self, value):


### PR DESCRIPTION
### Description
This PR enhances the `Heap` class to support both min-heap and max-heap behaviors through a `max_heap` flag passed at construction. Internally, a multiplier (`1` for min-heap, `-1` for max-heap) is used to invert values as needed, allowing reuse of existing heap logic without duplicating methods.

New public methods added:
- `is_min_heap()` — returns whether the current heap is a min-heap (`True`) or max-heap (`False`).
- `toggle_heap_type()` — flips the heap type in place, converting a min-heap to max-heap or vice versa, reheapifying accordingly.

### Changes
- Added `min_heap` constructor flag controlling heap type.
- Introduced `min_max_multiplier` internal attribute to apply value inversion logic.
- Implemented `is_min_heap()` for heap type introspection.
- Implemented `toggle_heap_type()` to convert the heap type on the fly.
- Updated documentation and README to reflect new API and usage.

### Notes
- This design maintains backward compatibility with existing heap logic and provides a clean, minimal interface to support max heaps.
- No tests were added in this PR; upcoming tickets will handle migrating existing tests to `pytest` and add coverage for these new methods.
  - Future work will include comprehensive testing and examples illustrating max-heap usage.